### PR TITLE
Zip importer now searches the zip file for any xlsx file

### DIFF
--- a/app/routines/exercises/import/zip.rb
+++ b/app/routines/exercises/import/zip.rb
@@ -12,13 +12,12 @@ module Exercises
                    translations: { outputs: { type: :verbatim } }
 
       # Imports Exercises from a zip file
-      def exec(zip_filename: 'exercises.zip',
-               excel_filename: 'exercises.xlsx',
+      def exec(filename: 'exercises.zip',
                author_id: Exercises::Import::Excel::DEFAULT_AUTHOR_ID,
                ch_id: Exercises::Import::Excel::DEFAULT_CH_ID,
                skip_first_row: true)
         # Create a temp directory and extract the zip file into it
-        zip_path = File.expand_path(zip_filename)
+        zip_path = File.expand_path(filename)
         Dir.mktmpdir do |dir|
           Dir.chdir(dir) do
             ::Zip::File.open(zip_path) do |zip_file|
@@ -27,9 +26,10 @@ module Exercises
               end
             end
 
-            # Import the spreadsheet from the temp directory
+            # Import the first spreadsheet found in the temp directory
+            xlsx_filename = Dir.glob('*.xlsx').first
             run(:import_spreadsheet,
-                filename: excel_filename,
+                filename: xlsx_filename,
                 author_id: author_id,
                 ch_id: ch_id,
                 skip_first_row: skip_first_row)

--- a/lib/tasks/exercises/import.rake
+++ b/lib/tasks/exercises/import.rake
@@ -23,14 +23,13 @@ namespace :exercises do
 
     # Imports exercises from a zip file
     # Arguments are, in order:
-    # zip_filename, excel_filename, author's user id, copyright holder's user id, skip_first_row
-    # Example: rake exercises:import:zip[exercises.zip,exercises.xlsx,1,2]
-    #          will import exercises from exercises.xlsx (within exercises.zip) and
+    # filename, author's user id, copyright holder's user id, skip_first_row
+    # Example: rake exercises:import:zip[exercises.zip,1,2]
+    #          will import exercises from the first xlsx file found within exercises.zip and
     #          assign the user with ID 1 as the author and
     #          solution author, and the user with ID 2 as the CR holder
     desc "import a zip file"
-    task :zip, [:zip_filename, :excel_filename,
-                :author_id, :ch_id, :skip_first_row] => :environment do |t, args|
+    task :zip, [:filename, :author_id, :ch_id, :skip_first_row] => :environment do |t, args|
       # Output import logging info to the console (except in the test environment)
       original_logger = Rails.logger
       begin

--- a/spec/lib/tasks/exercises/import_rake_spec.rb
+++ b/spec/lib/tasks/exercises/import_rake_spec.rb
@@ -28,13 +28,12 @@ describe 'exercises import' do
 
     let :run_rake_task do
       Rake::Task["exercises:import:zip"].reenable
-      Rake.application.invoke_task "exercises:import:zip[#{fixture_path},exercises.xlsx,42,10]"
+      Rake.application.invoke_task "exercises:import:zip[#{fixture_path},42,10]"
     end
 
     it 'passes arguments to Exercises::Import::Zip' do
       expect(Exercises::Import::Zip).to(
-        receive(:call).with(zip_filename: fixture_path,
-                            excel_filename: 'exercises.xlsx',
+        receive(:call).with(filename: fixture_path,
                             author_id: '42',
                             ch_id: '10')
       )

--- a/spec/routines/exercises/import/zip_spec.rb
+++ b/spec/routines/exercises/import/zip_spec.rb
@@ -3,7 +3,6 @@ require 'rails_helper'
 module Exercises::Import
   RSpec.describe Zip do
     let(:fixture_path) { 'spec/fixtures/sample_exercises.zip' }
-    let(:excel_path)   { 'exercises.xlsx' }
 
     let!(:author) { FactoryGirl.create :user }
     let!(:ch)     { FactoryGirl.create :user }
@@ -11,8 +10,7 @@ module Exercises::Import
     it 'imports the sample zip file' do
       attachment_count = Attachment.count
       expect {
-        Exercises::Import::Zip.call(zip_filename: fixture_path, excel_filename: excel_path,
-                                    author_id: author.id, ch_id: ch.id)
+        Exercises::Import::Zip.call(filename: fixture_path, author_id: author.id, ch_id: ch.id)
       }.to change{ Exercise.count }.by(215)
       expect(Attachment.count).to eq (attachment_count + 15)
 


### PR DESCRIPTION
 Instead of expecting an xlsx filename as argument