### PR TITLE
Draft API changes

### DIFF
--- a/app/controllers/api/v1/exercises_controller.rb
+++ b/app/controllers/api/v1/exercises_controller.rb
@@ -21,7 +21,7 @@ module Api::V1
       of the matching Exercises. Only Exercises visible to the caller will be
       returned. The schema for the returned JSON result is shown below.
 
-      #{json_schema(Api::V1::ExerciseSearchRepresenter, include: :readable)}            
+      #{json_schema(Api::V1::ExerciseSearchRepresenter, include: :readable)}
     EOS
     # Using route helpers doesn't work in test or production, probably has to do with initialization order
     example "#{api_example(url_base: 'https://exercises.openstax.org/api/exercises',
@@ -44,7 +44,7 @@ module Api::V1
                          (uses wildcard matching)
       * `number` &ndash; Matches the exercise number exactly.
       * `version` &ndash; Matches the exercise version exactly.
-      * `id` &ndash; Matches the exercise ID exactly.
+      * `id` &ndash; Matches the exercise ID or UID exactly.
       * `published_before` &ndash; Matches exercises published before the given date.
                                    Enclose date in quotes to avoid parsing errors.
 
@@ -67,7 +67,7 @@ module Api::V1
       The fields can be one of #{
         SearchExercises::SORTABLE_FIELDS.keys.collect{|sf| "`"+sf+"`"}.join(', ')
       }.
-      Sort directions can either be `ASC` for 
+      Sort directions can either be `ASC` for
       an ascending sort, or `DESC` for a
       descending sort. If not provided, an ascending sort is assumed. Sort
       directions should be separated from the fields by a space.
@@ -78,7 +78,8 @@ module Api::V1
       `number, version DESC` &ndash; sorts by number ascending, then by version descending
     EOS
     def index
-      standard_search(Exercise, SearchExercises, ExerciseSearchRepresenter, user: current_api_user)
+      standard_search(Exercise, SearchExercises, ExerciseSearchRepresenter,
+                      user: current_api_user)
     end
 
     ##########
@@ -89,7 +90,7 @@ module Api::V1
     description <<-EOS
       Creates an Exercise with the given attributes.
 
-      #{json_schema(Api::V1::ExerciseRepresenter, include: :writeable)}        
+      #{json_schema(Api::V1::ExerciseRepresenter, include: :writeable)}
     EOS
     def create
       user = current_human_user
@@ -108,11 +109,11 @@ module Api::V1
     # show #
     ########
 
-    api :GET, '/exercises/:id', 'Gets the specified Exercise'
+    api :GET, '/exercises/:uid', 'Gets the specified Exercise'
     description <<-EOS
-      Gets the Exercise that matches the provided ID.
+      Gets the Exercise that matches the provided UID.
 
-      #{json_schema(Api::V1::ExerciseRepresenter, include: :readable)}        
+      #{json_schema(Api::V1::ExerciseRepresenter, include: :readable)}
     EOS
     def show
       standard_read(@exercise)
@@ -122,11 +123,11 @@ module Api::V1
     # update #
     ##########
 
-    api :PUT, '/exercises/:id', 'Updates the specified Exercise'
+    api :PUT, '/exercises/:uid', 'Updates the specified Exercise'
     description <<-EOS
-      Updates the Exercise that matches the provided ID with the given attributes.
+      Updates the Exercise that matches the provided UID with the given attributes.
 
-      #{json_schema(Api::V1::ExerciseRepresenter, include: :writeable)}        
+      #{json_schema(Api::V1::ExerciseRepresenter, include: :writeable)}
     EOS
     def update
       standard_update(@exercise)
@@ -136,9 +137,9 @@ module Api::V1
     # destroy #
     ###########
 
-    api :DELETE, '/exercises/:id', 'Deletes the specified Exercise'
+    api :DELETE, '/exercises/:uid', 'Deletes the specified Exercise'
     description <<-EOS
-      Deletes the Exercise that matches the provided ID.
+      Deletes the Exercise that matches the provided UID.
     EOS
     def destroy
       standard_destroy(@exercise)
@@ -148,8 +149,9 @@ module Api::V1
 
     def get_exercise
       @exercise = Exercise.visible_for(current_api_user).with_uid(params[:id]).first || \
-        raise(ActiveRecord::RecordNotFound, "Couldn't find Exercise with 'uid'=#{params[:id]}")
+        raise(ActiveRecord::RecordNotFound,
+              "Couldn't find Exercise with 'uid'=#{params[:id]}")
     end
-    
+
   end
 end

--- a/app/controllers/api/v1/exercises_controller.rb
+++ b/app/controllers/api/v1/exercises_controller.rb
@@ -130,6 +130,11 @@ module Api::V1
       #{json_schema(Api::V1::ExerciseRepresenter, include: :writeable)}
     EOS
     def update
+      if @exercise.is_published?
+        version = params[:id].split('@').last
+        @exercise = @exercise.new_version if version == 'draft' || version == 'd'
+      end
+
       standard_update(@exercise)
     end
 

--- a/app/controllers/api/v1/publications_controller.rb
+++ b/app/controllers/api/v1/publications_controller.rb
@@ -16,10 +16,10 @@ module Api::V1
     # publish #
     ###########
 
-    api :PUT, '/object/:object_id/publish',
+    api :PUT, '/object/:object_uid/publish',
                'Publishes the specified object'
     description <<-EOS
-      Publishes the specified object.  
+      Publishes the specified object.
     EOS
     def publish
       OSU::AccessPolicy.require_action_allowed!(
@@ -32,10 +32,20 @@ module Api::V1
 
     protected
 
+    def get_exercise
+      Exercise.visible_for(current_api_user).with_uid(params[:exercise_id]).first || \
+        raise(ActiveRecord::RecordNotFound,
+              "Couldn't find Exercise with 'uid'=#{params[:id]}")
+    end
+
+    def get_solution
+      Solution.visible_for(current_api_user).with_uid(params[:solution_id]).first || \
+        raise(ActiveRecord::RecordNotFound,
+              "Couldn't find Solution with 'uid'=#{params[:id]}")
+    end
+
     def get_publishable
-      @publishable = params[:solution_id].nil? ? \
-                       Exercise.find(params[:exercise_id]) : \
-                       Solution.find(params[:solution_id])
+      @publishable = params[:solution_id].nil? ? get_exercise : get_solution
     end
 
   end

--- a/app/controllers/api/v1/publications_controller.rb
+++ b/app/controllers/api/v1/publications_controller.rb
@@ -35,13 +35,13 @@ module Api::V1
     def get_exercise
       Exercise.visible_for(current_api_user).with_uid(params[:exercise_id]).first || \
         raise(ActiveRecord::RecordNotFound,
-              "Couldn't find Exercise with 'uid'=#{params[:id]}")
+              "Couldn't find Exercise with 'uid'=#{params[:exercise_id]}")
     end
 
     def get_solution
       Solution.visible_for(current_api_user).with_uid(params[:solution_id]).first || \
         raise(ActiveRecord::RecordNotFound,
-              "Couldn't find Solution with 'uid'=#{params[:id]}")
+              "Couldn't find Solution with 'uid'=#{params[:solution_id]}")
     end
 
     def get_publishable

--- a/app/controllers/api/v1/solutions_controller.rb
+++ b/app/controllers/api/v1/solutions_controller.rb
@@ -1,6 +1,8 @@
 module Api::V1
   class SolutionsController < OpenStax::Api::V1::ApiController
 
+    before_filter :get_solution, only: [:show, :update, :destroy]
+
     resource_description do
       api_versions "v1"
       short_description 'A solution for an Exercise.'
@@ -32,7 +34,7 @@ module Api::V1
     # show #
     ########
 
-    api :GET, '/solutions/:id', 'Gets the specified Solution'
+    api :GET, '/solutions/:uid', 'Gets the specified Solution'
     description <<-EOS
       Shows the specified Solution, including high-level explanation and detailed explanation.
 
@@ -41,14 +43,15 @@ module Api::V1
       #{json_schema(Api::V1::SolutionRepresenter, include: :readable)}
     EOS
     def show
-      standard_read(Solution, params[:id])
+      standard_read(@solution)
     end
 
     ##########
     # create #
     ##########
 
-    api :POST, '/exercises/:exercise_id/solutions', 'Creates a new Solution for the given exercise'
+    api :POST, '/exercises/:exercise_uid/solutions',
+               'Creates a new Solution for the given exercise'
     description <<-EOS
       Creates a new Solution for the given exercise.
       The user is set as the author and copyright holder.
@@ -67,7 +70,7 @@ module Api::V1
     # update #
     ##########
 
-    api :PUT, '/solutions/:id', 'Updates the properties of a Solution'
+    api :PUT, '/solutions/:uid', 'Updates the properties of a Solution'
     description <<-EOS
       Updates the properties of the specified Solution.
 
@@ -76,21 +79,29 @@ module Api::V1
       #{json_schema(Api::V1::SolutionRepresenter, include: :writeable)}
     EOS
     def update
-      standard_update(Solution, params[:id])
+      standard_update(@solution)
     end
 
     ###########
     # destroy #
     ###########
 
-    api :DELETE, '/solutions/:id', 'Deletes the specified Solution'
+    api :DELETE, '/solutions/:uid', 'Deletes the specified Solution'
     description <<-EOS
       Deletes the specified Solution.
 
       The user must have permission to edit the solution.
     EOS
     def destroy
-      standard_destroy(Solution, params[:id])
+      standard_destroy(@solution)
+    end
+
+    protected
+
+    def get_solution
+      @exercise = Solution.visible_for(current_api_user).with_uid(params[:id]).first || \
+        raise(ActiveRecord::RecordNotFound,
+              "Couldn't find Solution with 'uid'=#{params[:id]}")
     end
 
   end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -1,5 +1,35 @@
 class Exercise < ActiveRecord::Base
 
+  # deep_clone does not iterate through hashes, so each hash must have only 1 key
+  NEW_VERSION_DUPED_ASSOCIATIONS = [
+    :attachments,
+    :logic,
+    :tags,
+    {
+      publication: [
+        :derivations,
+        :authors,
+        :copyright_holders,
+        :editors
+      ]
+    },
+    {
+      questions: [
+        :hints,
+        :answers,
+        {
+          stems: [
+            :stylings,
+            :combo_choices,
+            {
+              stem_answers: :answer
+            }
+          ]
+        }
+      ]
+    }
+  ]
+
   acts_as_votable
   parsable :stimulus
   publishable
@@ -26,6 +56,16 @@ class Exercise < ActiveRecord::Base
               stems: [:stylings, :combo_choices]
             ])
   }
+
+  def new_version
+    nv = deep_clone include: NEW_VERSION_DUPED_ASSOCIATIONS, use_dictionary: true
+    nv.publication.version = version + 1
+    nv.publication.published_at = nil
+    nv.publication.yanked_at = nil
+    nv.publication.embargoed_until = nil
+    nv.publication.major_change = false
+    nv
+  end
 
   protected
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -55,6 +55,7 @@ class Publication < ActiveRecord::Base
 
   def publish
     self.published_at = Time.now
+    self
   end
 
   protected

--- a/lib/publishable.rb
+++ b/lib/publishable.rb
@@ -41,7 +41,9 @@ module Publishable
               pub_conditions = { number: number }
               if version.nil?
                 relation = relation.where{ publication.published_at != nil }
-              elsif version != 'draft' && version != 'd'
+              elsif version == 'draft' || version == 'd'
+                pub_conditions[:published_at] = nil
+              else
                 pub_conditions[:version] = version
               end
               relation.where(publication: pub_conditions)

--- a/lib/publishable.rb
+++ b/lib/publishable.rb
@@ -41,9 +41,7 @@ module Publishable
               pub_conditions = { number: number }
               if version.nil?
                 relation = relation.where{ publication.published_at != nil }
-              elsif version == 'draft' || version == 'd'
-                pub_conditions[:published_at] = nil
-              else
+              elsif version != 'draft' && version != 'd'
                 pub_conditions[:version] = version
               end
               relation.where(publication: pub_conditions)

--- a/spec/controllers/api/v1/exercises_controller_spec.rb
+++ b/spec/controllers/api/v1/exercises_controller_spec.rb
@@ -269,6 +269,7 @@ module Api::V1
         @exercise.publication.publish.save!
         exercise_2 = @exercise.new_version
         exercise_2.save!
+        exercise_2.reload
 
         api_patch :update, user_token, parameters: { id: "#{@exercise.number}@draft" },
                                        raw_post_data: { title: "Ipsum lorem" }

--- a/spec/controllers/api/v1/exercises_controller_spec.rb
+++ b/spec/controllers/api/v1/exercises_controller_spec.rb
@@ -8,13 +8,13 @@ module Api::V1
     let!(:admin)       { FactoryGirl.create :user, :administrator, :agreed_to_terms }
 
     let!(:user_token)        { FactoryGirl.create :doorkeeper_access_token,
-                                                  application: application, 
+                                                  application: application,
                                                   resource_owner_id: user.id }
     let!(:admin_token)       { FactoryGirl.create :doorkeeper_access_token,
-                                                  application: application, 
+                                                  application: application,
                                                   resource_owner_id: admin.id }
-    let!(:application_token) { FactoryGirl.create :doorkeeper_access_token, 
-                                                  application: application, 
+    let!(:application_token) { FactoryGirl.create :doorkeeper_access_token,
+                                                  application: application,
                                                   resource_owner_id: nil }
 
     before(:each) do
@@ -165,8 +165,17 @@ module Api::V1
         expect(response.body).to eq(expected_response)
       end
 
-      it "returns the latest visible Exercise if no version is specified" do
+      it "returns the latest published Exercise if no version is specified" do
         api_get :show, user_token, parameters: { id: @exercise.number }
+        expect(response).to have_http_status(:success)
+
+        expected_response = Api::V1::ExerciseRepresenter.new(@exercise).to_json
+
+        expect(response.body).to eq(expected_response)
+      end
+
+      it "returns the latest draft Exercise if \"draft\" is given as the version" do
+        api_get :show, user_token, parameters: { id: "#{@exercise.number}@draft" }
         expect(response).to have_http_status(:success)
 
         expected_response = Api::V1::ExerciseRepresenter.new(@exercise_2.reload).to_json

--- a/spec/controllers/api/v1/exercises_controller_spec.rb
+++ b/spec/controllers/api/v1/exercises_controller_spec.rb
@@ -148,12 +148,7 @@ module Api::V1
         @exercise.save!
         @exercise.reload
 
-        @exercise_2 = FactoryGirl.build(:exercise)
-        @exercise_2.publication.editors << FactoryGirl.build(
-          :editor, user: user, publication: @exercise_2.publication
-        )
-        @exercise_2.publication.number = @exercise.publication.number
-        @exercise_2.publication.version = @exercise.publication.version + 1
+        @exercise_2 = @exercise.new_version
         @exercise_2.save!
       end
 
@@ -175,7 +170,7 @@ module Api::V1
         expect(response.body).to eq(expected_response)
       end
 
-      it "returns the latest draft Exercise if \"draft\" is given as the version" do
+      it "returns the latest draft Exercise if \"@draft\" is requested" do
         api_get :show, user_token, parameters: { id: "#{@exercise.number}@draft" }
         expect(response).to have_http_status(:success)
 
@@ -184,14 +179,23 @@ module Api::V1
         expect(response.body).to eq(expected_response)
       end
 
-      it "returns the latest published Exercise if no draft is available" do
+      it "creates a new draft version if no draft and \"@draft\" is requested" do
         @exercise_2.destroy
 
-        api_get :show, user_token, parameters: { id: "#{@exercise.number}@draft" }
+        expect{ api_get :show, user_token, parameters: { id: "#{@exercise.number}@draft" } }.to(
+          change{ Exercise.count }.by(1)
+        )
         expect(response).to have_http_status(:success)
 
-        expected_response = Api::V1::ExerciseRepresenter.new(@exercise).to_json
+        new_exercise = Exercise.order(:created_at).last
+        expect(new_exercise.id).not_to eq @exercise.id
+        expect(new_exercise.number).to eq @exercise.number
+        expect(new_exercise.version).to eq @exercise.version + 1
 
+        expect(new_exercise.attributes.except('id', 'uid', 'title', 'created_at', 'updated_at'))
+          .to eq(@exercise.attributes.except('id', 'uid', 'title', 'created_at', 'updated_at'))
+
+        expected_response = Api::V1::ExerciseRepresenter.new(new_exercise).to_json
         expect(response.body).to eq(expected_response)
       end
 
@@ -249,7 +253,7 @@ module Api::V1
           .to eq(@old_attributes.except('title', 'updated_at'))
       end
 
-      it "fails if the exercise is published and draft was not requested" do
+      it "fails if the exercise is published and \"@draft\" was not requested" do
         @exercise.publication.publish.save!
 
         expect{ api_patch :update, user_token, parameters: { id: @exercise.uid },
@@ -261,11 +265,35 @@ module Api::V1
         expect(@exercise.attributes).to eq @old_attributes
       end
 
-      it "creates a new version if the exercise is published and draft is requested" do
+      it "updates the latest draft Exercise if \"@draft\" is requested" do
         @exercise.publication.publish.save!
+        exercise_2 = @exercise.new_version
+        exercise_2.save!
 
         api_patch :update, user_token, parameters: { id: "#{@exercise.number}@draft" },
                                        raw_post_data: { title: "Ipsum lorem" }
+        expect(response).to have_http_status(:success)
+        @exercise.reload
+
+        expect(@exercise.attributes).to eq @old_attributes
+
+        uid = JSON.parse(response.body)['uid']
+        new_exercise = Exercise.with_uid(uid).first
+        new_attributes = new_exercise.attributes
+
+        expect(new_exercise.title).to eq "Ipsum lorem"
+        expect(new_attributes.except('title', 'updated_at'))
+          .to eq(exercise_2.attributes.except('title', 'updated_at'))
+      end
+
+      it "creates a new draft version if no draft and \"@draft\" is requested" do
+        @exercise.publication.publish.save!
+
+        expect{
+          api_patch :update, user_token, parameters: { id: "#{@exercise.number}@draft" },
+                                         raw_post_data: { title: "Ipsum lorem" } }.to(
+          change{ Exercise.count }.by(1)
+        )
         expect(response).to have_http_status(:success)
         @exercise.reload
 

--- a/spec/controllers/api/v1/publications_controller_spec.rb
+++ b/spec/controllers/api/v1/publications_controller_spec.rb
@@ -25,15 +25,14 @@ module Api::V1
     }
 
     context "PUT publish" do
-      context "when given an exercise_id only" do
+      context "when given an exercise_id" do
         it "publishes the requested exercise" do
           expect(exercise.reload.is_published?).to eq false
 
           api_put :publish, exercise_author_token,
                              parameters: { exercise_id: exercise.id.to_s }
 
-          expected_response = Api::V1::ExerciseRepresenter.new(exercise.reload)
-                                                          .to_json
+          expected_response = Api::V1::ExerciseRepresenter.new(exercise.reload).to_json
           expect(response).to have_http_status(:success)
           expect(JSON.parse(response.body)).to eq JSON.parse(expected_response)
           expect(exercise.is_published?).to eq true
@@ -50,8 +49,7 @@ module Api::V1
             solution_id: solution.id.to_s
           }
 
-          expected_response = Api::V1::SolutionRepresenter.new(solution.reload)
-                                                          .to_json
+          expected_response = Api::V1::SolutionRepresenter.new(solution.reload).to_json
           expect(response).to have_http_status(:success)
           expect(JSON.parse(response.body)).to eq JSON.parse(expected_response)
           expect(solution.is_published?).to eq true

--- a/spec/controllers/api/v1/publications_controller_spec.rb
+++ b/spec/controllers/api/v1/publications_controller_spec.rb
@@ -30,7 +30,7 @@ module Api::V1
           expect(exercise.reload.is_published?).to eq false
 
           api_put :publish, exercise_author_token,
-                             parameters: { exercise_id: exercise.id.to_s }
+                             parameters: { exercise_id: exercise.uid.to_s }
 
           expected_response = Api::V1::ExerciseRepresenter.new(exercise.reload).to_json
           expect(response).to have_http_status(:success)
@@ -40,13 +40,13 @@ module Api::V1
       end
 
       context "when given a solution_id" do
-        it "publishes the requested solution" do
+        it "publishes the requested solution (ignores other parameters)" do
           expect(solution.reload.is_published?).to eq false
 
           api_put :publish, solution_author_token, parameters: {
-            exercise_id: solution.question.exercise_id.to_s,
-            question_id: solution.question_id,
-            solution_id: solution.id.to_s
+            exercise_id: solution.question.exercise.uid.to_s,
+            question_id: solution.question.id,
+            solution_id: solution.uid.to_s
           }
 
           expected_response = Api::V1::SolutionRepresenter.new(solution.reload).to_json

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -1,24 +1,22 @@
 require "rails_helper"
 
 module Api::V1
-  describe UsersController, :type => :controller,
-                            :api => true,
-                            :version => :v1 do
+  describe UsersController, type: :controller, api: true, version: :v1 do
 
     let!(:application)     { FactoryGirl.create :doorkeeper_application }
     let!(:user)          { FactoryGirl.create :user, :agreed_to_terms }
     let!(:admin)      { FactoryGirl.create :user, :administrator, :agreed_to_terms }
 
     let!(:user_token)    { FactoryGirl.create :doorkeeper_access_token,
-                                              application: application, 
+                                              application: application,
                                               resource_owner_id: user.id }
 
     let!(:admin_token)    { FactoryGirl.create :doorkeeper_access_token,
-                                               application: application, 
+                                               application: application,
                                                resource_owner_id: admin.id }
 
-    let!(:application_token) { FactoryGirl.create :doorkeeper_access_token, 
-                                                  application: application, 
+    let!(:application_token) { FactoryGirl.create :doorkeeper_access_token,
+                                                  application: application,
                                                   resource_owner_id: nil }
 
     describe "GET index" do
@@ -150,14 +148,14 @@ module Api::V1
           full_name: user.full_name,
           title: user.title
         }.to_json
-        
+
         expect(response.body).to eq(expected_response)
       end
 
       it "ignores id parameters" do
         api_get :show, user_token, parameters: {id: admin.id, user_id: admin.id}
         expect(response).to have_http_status(:success)
-        
+
         expected_response = {
           id: user.id,
           username: user.username,
@@ -166,7 +164,7 @@ module Api::V1
           full_name: user.full_name,
           title: user.title
         }.to_json
-        
+
         expect(response.body).to eq(expected_response)
       end
 


### PR DESCRIPTION
- Made API use of the UID consistent
- "draft" or "d" can now be specified as the version
- A draft is automatically created if "draft" or "d" is requested on a show or update request that would otherwise find a published exercise.