### PR TITLE
Stubbed out the group creation call when creating Doorkeeper Apps

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,7 +52,7 @@ gem 'openstax_utilities'
 gem 'whenever'
 
 # OpenStax Accounts integration
-gem 'openstax_accounts', '~> 6.1.5'
+gem 'openstax_accounts', '~> 6.1.6'
 
 # Access control for API's
 gem 'doorkeeper'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -333,7 +333,7 @@ GEM
     omniauth-oauth2 (1.4.0)
       oauth2 (~> 1.0)
       omniauth (~> 1.2)
-    openstax_accounts (6.1.5)
+    openstax_accounts (6.1.6)
       action_interceptor (>= 1.0)
       keyword_search (>= 1.0.0)
       lev (>= 2.2.1)
@@ -609,7 +609,7 @@ DEPENDENCIES
   mini_magick
   newrelic_rpm
   nifty-generators
-  openstax_accounts (~> 6.1.5)
+  openstax_accounts (~> 6.1.6)
   openstax_api (~> 6.1.0)
   openstax_rescue_from (~> 1.5.0)
   openstax_utilities

--- a/lib/tasks/openstax/applications.rake
+++ b/lib/tasks/openstax/applications.rake
@@ -50,21 +50,22 @@ namespace :openstax do
     end
 
     # This task gets information about all the authorized oauth
-    # applications. For each application found, it returns the
+    # applications.  For each application found, it returns the
     # application id and secret as a JSON object list.
-    task info: :environment do
+    desc "Save information about known client applications"
+    task :save_json, [:filename] => :environment do |t, args|
+      filename = args[:filename] || 'client_apps.json'
+
       apps = Doorkeeper::Application.where(name: DEFAULT_APP_NAMES)
 
-      apps_hash = apps.map do |app|
-        {
-          name: app.name,
-          client_id: app.uid,
-          secret: app.secret,
-          redirect_uri: app.redirect_uri
-        }
+      apps = apps.map do |app|
+        { name: app.name, client_id: app.uid, secret: app.secret, redirect_uri: app.redirect_uri }
       end
 
-      puts JSON.generate(apps_hash)
+      File.open(filename, 'w') do |f|
+        f.write(JSON.pretty_generate(apps))
+        puts "Generated the client application json file @ #{File.expand_path(f.path)}"
+      end
     end
   end
 end


### PR DESCRIPTION
The call was failing because only (non-temp) users can create groups in Accounts. I don't care about this group being persisted in Accounts, so I stubbed out the create call.