### PR TITLE
home page cleanup

### DIFF
--- a/app/views/layouts/_application_bottom_nav.html.erb
+++ b/app/views/layouts/_application_bottom_nav.html.erb
@@ -2,7 +2,7 @@
   <div id="bottom-nav-content">
 
     <div id="bottom-nav-links">
-
+<% if false %>
       <%= link_to "Terms of Use", main_app.terms_path %>
       <%= image_tag "links_dash.png" %>
 
@@ -11,15 +11,15 @@
 
       <%= link_to "Publishing Agreement", main_app.publishing_path %>
       <%= image_tag "links_dash.png" %>
-      
+
       <%= link_to "About", main_app.about_path %>
       <%= image_tag "links_dash.png" %>
 
       <%= link_to "Developers", main_app.developers_path %>
-      <%= image_tag "links_dash.png" %>      
+      <%= image_tag "links_dash.png" %>
 
       <%= link_to "Contact Us", main_app.contact_path %>
-
+<% end %>
     </div>
 
   </div>

--- a/app/views/layouts/_application_footer.html.erb
+++ b/app/views/layouts/_application_footer.html.erb
@@ -1,4 +1,4 @@
-<%# Copyright 2011-2013 Rice University. Licensed under the Affero General Public 
+<%# Copyright 2011-2013 Rice University. Licensed under the Affero General Public
     License version 3 or later.  See the COPYRIGHT file for details. %>
 
 <div id="application-footer-frame">
@@ -11,7 +11,8 @@
     </div>
 
     <div id="footer-copyright">
-      <%= link_to OpenStax::Utilities::Text.copyright('2013', COPYRIGHT_HOLDER), main_app.copyright_path %> 
+      <%= link_to OpenStax::Utilities::Text.copyright('2013', COPYRIGHT_HOLDER), main_app.copyright_path %>
+ <% if false %>
       <br/>
 
       Supported by
@@ -19,6 +20,7 @@
       <%= link_to "Google", "http://www.google.org" %>, and
       <%= link_to "Rice University", "http://www.rice.edu" %>
       <br/>
+<% end %>
     </div>
 
   </div>

--- a/app/views/webview/home.html.erb
+++ b/app/views/webview/home.html.erb
@@ -1,2 +1,0 @@
-<h1>Webview#home</h1>
-<p>Find me in app/views/webview/home.html.erb</p>


### PR DESCRIPTION
Got rid of boilerplate Rails templates on the home page and removed older "supported by" text.

From:

![image](https://cloud.githubusercontent.com/assets/1001691/11805134/460c650a-a2be-11e5-87e7-4ecd191eac68.png)

To:

![image](https://cloud.githubusercontent.com/assets/1001691/11805143/4ee577c0-a2be-11e5-8596-fbd6e1f96ab8.png)
