### PR TITLE
Fix CORS by allowing all origins for exercises (for now)

### DIFF
--- a/config/initializers/openstax_api.rb
+++ b/config/initializers/openstax_api.rb
@@ -1,0 +1,3 @@
+OpenStax::Api.configure do |config|
+  config.validate_cors_origin = ->(request) { true }
+end


### PR DESCRIPTION
I think it's fine to allow all origins because it's what we did before and the allow credentials header is still disabled. Thoughts?