### PR TITLE
Added explicit answer ordering based on the sort_position and specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -114,7 +114,6 @@ GEM
       compass (~> 1.0.0)
       sass-rails (<= 5.0.1)
       sprockets (< 2.13)
-    concurrent-ruby (1.0.0)
     coveralls (0.7.12)
       multi_json (~> 1.10)
       rest-client (>= 1.6.8, < 2)
@@ -647,4 +646,4 @@ DEPENDENCIES
   yaml_db
 
 BUNDLED WITH
-   1.10.6
+   1.11.2

--- a/app/models/answer.rb
+++ b/app/models/answer.rb
@@ -4,7 +4,7 @@ class Answer < ActiveRecord::Base
 
   parsable :content
 
-  belongs_to :question
+  sortable_belongs_to :question, inverse_of: :answers
 
   has_many :stem_answers, dependent: :destroy
 

--- a/app/models/derivation.rb
+++ b/app/models/derivation.rb
@@ -1,13 +1,10 @@
 class Derivation < ActiveRecord::Base
 
-  sortable_belongs_to :derived_publication, class_name: 'Publication',
-                                            inverse_of: :sources
-  belongs_to :source_publication, class_name: 'Publication',
-                                  inverse_of: :derivations
+  sortable_belongs_to :derived_publication, class_name: 'Publication', inverse_of: :sources
+  belongs_to :source_publication, class_name: 'Publication', inverse_of: :derivations
 
   validates :derived_publication, presence: true
-  validates :source_publication,
-            uniqueness: { scope: :derived_publication_id, allow_nil: true }
+  validates :source_publication, uniqueness: { scope: :derived_publication_id, allow_nil: true }
   validate :different_publications, :source_or_custom
 
   protected

--- a/app/models/hint.rb
+++ b/app/models/hint.rb
@@ -1,6 +1,6 @@
 class Hint < ActiveRecord::Base
 
-  sortable_belongs_to :question
+  sortable_belongs_to :question, inverse_of: :hints
 
   validates :question, presence: true
   validates :content, presence: true

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -7,10 +7,12 @@ class Question < ActiveRecord::Base
   belongs_to :exercise
 
   has_many :stems, dependent: :destroy
-  has_many :answers, dependent: :destroy
+
+  sortable_has_many :answers, dependent: :destroy, inverse_of: :question
+
   has_many :solutions, dependent: :destroy
 
-  sortable_has_many :hints, dependent: :destroy
+  sortable_has_many :hints, dependent: :destroy, inverse_of: :question
 
   has_many :parent_dependencies, class_name: 'QuestionDependency',
            foreign_key: :dependent_question_id, dependent: :destroy,

--- a/app/models/stem_answer.rb
+++ b/app/models/stem_answer.rb
@@ -12,8 +12,7 @@ class StemAnswer < ActiveRecord::Base
   protected
 
   def same_question
-    return if stem.nil? || answer.nil? || \
-              stem.question == answer.question
+    return if stem.nil? || answer.nil? || stem.question == answer.question
     errors.add(:answer, 'must belong to the same question as the stem')
     false
   end

--- a/app/representers/api/v1/question_representer.rb
+++ b/app/representers/api/v1/question_representer.rb
@@ -9,6 +9,14 @@ module Api::V1
              readable: true,
              setter: lambda { |value, args| self.temp_id = value }
 
+    property :answer_order_matters,
+             as: :is_answer_order_important,
+             writeable: true,
+             readable: true,
+             schema_info: {
+               type: 'boolean'
+             }
+
     property :stimulus,
              as: :stimulus_html,
              type: String,
@@ -29,7 +37,6 @@ module Api::V1
                decorator: AnswerRepresenter,
                writeable: true,
                readable: true,
-               getter: ->(*) { answers.sort_by(&:id) },
                schema_info: {
                  required: true
                }

--- a/app/representers/api/v1/simple_question_representer.rb
+++ b/app/representers/api/v1/simple_question_representer.rb
@@ -8,6 +8,14 @@ module Api::V1
              writeable: false,
              readable: true
 
+    property :answer_order_matters,
+             as: :is_answer_order_important,
+             writeable: true,
+             readable: true,
+             schema_info: {
+               type: 'boolean'
+             }
+
     property :stimulus,
              as: :stimulus_html,
              type: String,
@@ -33,7 +41,6 @@ module Api::V1
                instance: lambda { |*| Answer.new(question: self) },
                writeable: true,
                readable: true,
-               getter: ->(*) { answers.sort_by(&:id) },
                schema_info: {
                  required: true
                }

--- a/db/migrate/20160212204251_add_sort_position_to_answers.rb
+++ b/db/migrate/20160212204251_add_sort_position_to_answers.rb
@@ -1,0 +1,31 @@
+class AddSortPositionToAnswers < ActiveRecord::Migration
+  def change
+    add_sortable_column :answers, null: true
+
+    # Make each exercise's answers have the same sort_position as the first imported version
+    reversible do |dir|
+      dir.up do
+        Exercise.preload([:publication, {questions: :answers}])
+                .group_by(&:number).each do |number, exercises|
+          answer_position = {}
+          exercises.sort_by(&:version).each do |exercise|
+            exercise.questions.each do |question|
+              positions = []
+              question.answers.sort_by(&:id).each_with_index do |answer, index|
+                content = answer.content.downcase.strip
+                position = answer_position[content] || index + 1
+                position += 1 while positions.include?(position)
+                answer.update_attribute(:sort_position, position)
+                answer_position[content] = position
+                positions << position
+              end
+            end
+          end
+        end
+      end
+    end
+
+    change_column_null :answers, :sort_position, false
+    add_sortable_index :answers, scope: :question_id
+  end
+end

--- a/db/migrate/20160212211016_add_answer_order_matters_to_questions.rb
+++ b/db/migrate/20160212211016_add_answer_order_matters_to_questions.rb
@@ -1,0 +1,5 @@
+class AddAnswerOrderMattersToQuestions < ActiveRecord::Migration
+  def change
+    add_column :questions, :answer_order_matters, :boolean, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150225002247) do
+ActiveRecord::Schema.define(version: 20160212211016) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -25,12 +25,14 @@ ActiveRecord::Schema.define(version: 20150225002247) do
   add_index "administrators", ["user_id"], name: "index_administrators_on_user_id", unique: true, using: :btree
 
   create_table "answers", force: :cascade do |t|
-    t.integer  "question_id", null: false
-    t.text     "content",     null: false
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.integer  "question_id",   null: false
+    t.text     "content",       null: false
+    t.datetime "created_at",    null: false
+    t.datetime "updated_at",    null: false
+    t.integer  "sort_position", null: false
   end
 
+  add_index "answers", ["question_id", "sort_position"], name: "index_answers_on_question_id_and_sort_position", unique: true, using: :btree
   add_index "answers", ["question_id"], name: "index_answers_on_question_id", using: :btree
 
   create_table "attachments", force: :cascade do |t|
@@ -485,10 +487,11 @@ ActiveRecord::Schema.define(version: 20150225002247) do
   add_index "question_dependencies", ["parent_question_id"], name: "index_question_dependencies_on_parent_question_id", using: :btree
 
   create_table "questions", force: :cascade do |t|
-    t.integer  "exercise_id", null: false
+    t.integer  "exercise_id",                         null: false
     t.text     "stimulus"
-    t.datetime "created_at",  null: false
-    t.datetime "updated_at",  null: false
+    t.datetime "created_at",                          null: false
+    t.datetime "updated_at",                          null: false
+    t.boolean  "answer_order_matters", default: true, null: false
   end
 
   add_index "questions", ["exercise_id"], name: "index_questions_on_exercise_id", using: :btree

--- a/spec/factories/stem_answers.rb
+++ b/spec/factories/stem_answers.rb
@@ -1,7 +1,9 @@
 FactoryGirl.define do
   factory :stem_answer do
     stem
-    answer { build(:answer, question: stem.question) }
+    answer do
+      build(:answer, question: stem.question).tap{ |answer| stem.question.answers << answer }
+    end
     feedback '<p>Some feedback</p>'
   end
 end

--- a/spec/models/administrator_spec.rb
+++ b/spec/models/administrator_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Administrator, :type => :model do
+RSpec.describe Administrator, type: :model do
 
   subject { FactoryGirl.create(:administrator) }
 

--- a/spec/models/anonymous_user_spec.rb
+++ b/spec/models/anonymous_user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe AnonymousUser, :type => :model do
+RSpec.describe AnonymousUser, type: :model do
 
   it 'is a singleton' do
     expect(AnonymousUser).to respond_to(:instance)

--- a/spec/models/answer_spec.rb
+++ b/spec/models/answer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Answer, :type => :model do
+RSpec.describe Answer, type: :model do
 
   it { is_expected.to belong_to(:question) }
 

--- a/spec/models/attachment_spec.rb
+++ b/spec/models/attachment_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Attachment, :type => :model do
+RSpec.describe Attachment, type: :model do
 
   subject(:attachment) { FactoryGirl.create :attachment }
   let!(:asset_path)    { attachment.asset.path }

--- a/spec/models/author_spec.rb
+++ b/spec/models/author_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Author, :type => :model do
+RSpec.describe Author, type: :model do
 
   subject { FactoryGirl.create(:author) }
 

--- a/spec/models/class_license_spec.rb
+++ b/spec/models/class_license_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ClassLicense, :type => :model do
+RSpec.describe ClassLicense, type: :model do
 
   subject { FactoryGirl.create(:class_license) }
 

--- a/spec/models/combo_choice_answer_spec.rb
+++ b/spec/models/combo_choice_answer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ComboChoiceAnswer, :type => :model do
+RSpec.describe ComboChoiceAnswer, type: :model do
 
   subject { FactoryGirl.create(:combo_choice_answer) }
 

--- a/spec/models/combo_choice_spec.rb
+++ b/spec/models/combo_choice_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ComboChoice, :type => :model do
+RSpec.describe ComboChoice, type: :model do
 
   it { is_expected.to belong_to(:stem) }
 

--- a/spec/models/copyright_holder_spec.rb
+++ b/spec/models/copyright_holder_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe CopyrightHolder, :type => :model do
+RSpec.describe CopyrightHolder, type: :model do
 
   subject { FactoryGirl.create(:copyright_holder) }
 

--- a/spec/models/deputization_spec.rb
+++ b/spec/models/deputization_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Deputization, :type => :model do
+RSpec.describe Deputization, type: :model do
 
   it { is_expected.to belong_to(:deputy) }
   it { is_expected.to belong_to(:deputizer) }

--- a/spec/models/derivation_spec.rb
+++ b/spec/models/derivation_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Derivation, :type => :model do
+RSpec.describe Derivation, type: :model do
 
   subject { FactoryGirl.create :derivation }
 

--- a/spec/models/editor_spec.rb
+++ b/spec/models/editor_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Editor, :type => :model do
+RSpec.describe Editor, type: :model do
 
   subject { FactoryGirl.create(:editor) }
 

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Exercise, :type => :model do
+RSpec.describe Exercise, type: :model do
 
   it { is_expected.to have_many(:questions).dependent(:destroy)
                                            .autosave(true) }

--- a/spec/models/exercise_tag_spec.rb
+++ b/spec/models/exercise_tag_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe ExerciseTag, :type => :model do
+RSpec.describe ExerciseTag, type: :model do
   subject { FactoryGirl.create :exercise_tag }
 
   it { is_expected.to belong_to(:exercise) }

--- a/spec/models/hint_spec.rb
+++ b/spec/models/hint_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Hint, :type => :model do
+RSpec.describe Hint, type: :model do
 
   it { is_expected.to belong_to(:question) }
 

--- a/spec/models/license_compatibility_spec.rb
+++ b/spec/models/license_compatibility_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe LicenseCompatibility, :type => :model do
+RSpec.describe LicenseCompatibility, type: :model do
 
   subject { FactoryGirl.create(:license_compatibility) }
 

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe License, :type => :model do
+RSpec.describe License, type: :model do
 
   subject { FactoryGirl.create(:license) }
 

--- a/spec/models/list_editor_spec.rb
+++ b/spec/models/list_editor_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ListEditor, :type => :model do
+RSpec.describe ListEditor, type: :model do
 
   it { is_expected.to belong_to(:list) }
   it { is_expected.to belong_to(:editor) }

--- a/spec/models/list_exercise_spec.rb
+++ b/spec/models/list_exercise_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ListExercise, :type => :model do
+RSpec.describe ListExercise, type: :model do
 
   subject { FactoryGirl.create :list_exercise }
 

--- a/spec/models/list_nesting_spec.rb
+++ b/spec/models/list_nesting_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ListNesting, :type => :model do
+RSpec.describe ListNesting, type: :model do
 
   subject { FactoryGirl.create(:list_nesting) }
 

--- a/spec/models/list_owner_spec.rb
+++ b/spec/models/list_owner_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ListOwner, :type => :model do
+RSpec.describe ListOwner, type: :model do
 
   it { is_expected.to belong_to(:list) }
   it { is_expected.to belong_to(:owner) }

--- a/spec/models/list_reader_spec.rb
+++ b/spec/models/list_reader_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe ListReader, :type => :model do
+RSpec.describe ListReader, type: :model do
 
   it { is_expected.to belong_to(:list) }
   it { is_expected.to belong_to(:reader) }

--- a/spec/models/list_spec.rb
+++ b/spec/models/list_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe List, :type => :model do
+RSpec.describe List, type: :model do
 
   it { is_expected.to have_one(:parent_list_nesting) }
   it { is_expected.to have_many(:child_list_nestings) }

--- a/spec/models/logic_spec.rb
+++ b/spec/models/logic_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Logic, :type => :model do
+RSpec.describe Logic, type: :model do
 
   it { is_expected.to belong_to(:parent) }
 

--- a/spec/models/logic_variable_spec.rb
+++ b/spec/models/logic_variable_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe LogicVariable, :type => :model do
+RSpec.describe LogicVariable, type: :model do
 
   INVALID_VARIABLES = ["'hello'", '"hello"', 'hel lo', '$hello$', '<hello>',
                        'hello?', 'http://hello', '/hel/lo', 'hel; lo']

--- a/spec/models/logic_variable_value_spec.rb
+++ b/spec/models/logic_variable_value_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe LogicVariableValue, :type => :model do
+RSpec.describe LogicVariableValue, type: :model do
 
   subject { FactoryGirl.create(:logic_variable_value) }
 
@@ -10,7 +10,6 @@ RSpec.describe LogicVariableValue, :type => :model do
   it { is_expected.to validate_presence_of(:seed) }
   it { is_expected.to validate_presence_of(:value) }
 
-  it { is_expected.to validate_uniqueness_of(:seed)
-                        .scoped_to(:logic_variable_id) }
+  it { is_expected.to validate_uniqueness_of(:seed).scoped_to(:logic_variable_id) }
 
 end

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Publication, :type => :model do
+RSpec.describe Publication, type: :model do
 
   subject { FactoryGirl.create :publication }
 

--- a/spec/models/question_dependency_spec.rb
+++ b/spec/models/question_dependency_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe QuestionDependency, :type => :model do
+RSpec.describe QuestionDependency, type: :model do
 
   subject { FactoryGirl.create(:question_dependency) }
 

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Question, :type => :model do
+RSpec.describe Question, type: :model do
 
   it { is_expected.to have_many(:stems).dependent(:destroy) }
   it { is_expected.to have_many(:answers).dependent(:destroy) }

--- a/spec/models/solution_spec.rb
+++ b/spec/models/solution_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Solution, :type => :model do
+RSpec.describe Solution, type: :model do
 
   it { is_expected.to belong_to(:question) }
 

--- a/spec/models/stem_answer_spec.rb
+++ b/spec/models/stem_answer_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe StemAnswer, :type => :model do
+RSpec.describe StemAnswer, type: :model do
 
   subject { FactoryGirl.create(:stem_answer) }
 

--- a/spec/models/stem_spec.rb
+++ b/spec/models/stem_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Stem, :type => :model do
+RSpec.describe Stem, type: :model do
 
   it { is_expected.to belong_to(:question) }
 

--- a/spec/models/styling_spec.rb
+++ b/spec/models/styling_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe Styling, :type => :model do
+RSpec.describe Styling, type: :model do
 
   it { is_expected.to belong_to(:stylable) }
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Tag, :type => :model do
+RSpec.describe Tag, type: :model do
   subject { FactoryGirl.create :tag }
 
   it { is_expected.to have_many(:exercise_tags).dependent(:destroy) }

--- a/spec/models/trusted_application_spec.rb
+++ b/spec/models/trusted_application_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe TrustedApplication, :type => :model do
+RSpec.describe TrustedApplication, type: :model do
 
   subject { FactoryGirl.create(:trusted_application) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-RSpec.describe User, :type => :model do
+RSpec.describe User, type: :model do
 
   subject { FactoryGirl.create :user }
 

--- a/spec/representers/api/v1/question_representer_spec.rb
+++ b/spec/representers/api/v1/question_representer_spec.rb
@@ -43,6 +43,18 @@ module Api::V1
       end
     end
 
+    context 'answer_order_matters' do
+      it 'can be read' do
+        allow(question).to receive(:answer_order_matters).and_return(false)
+        expect(representation).to include('is_answer_order_important' => false)
+      end
+
+      it 'can be written' do
+        described_class.new(question).from_json({'is_answer_order_important' => false}.to_json)
+        expect(question).to have_received(:answer_order_matters=).with(false)
+      end
+    end
+
     context 'stimulus' do
       it 'can be read' do
         allow(question).to receive(:stimulus).and_return('This question is cool.')
@@ -64,31 +76,58 @@ module Api::V1
         expect(representation).to include('stems' => stem_representations)
       end
 
-      xit 'can be written' do
+      it 'can be written' do
+        stems = [Stem.new(content: 'Yes, I do!')]
+        stem_representations = stems.collect{ |stem| StemRepresenter.new(stem).to_hash }
+        described_class.new(question).from_json({ 'stems' => stem_representations }.to_json)
+        expect(question).to have_received(:stems=).with([ a_kind_of(Stem) ]) do |stems|
+          expect(stems.first.content).to eq 'Yes, I do!'
+        end
       end
     end
 
     context 'answers' do
       it 'can be read' do
         answer_1 = instance_spy(Answer)
-        allow(answer_1).to receive(:id).and_return(2)
+        allow(answer_1).to receive(:id).and_return(1)
         allow(answer_1).to receive(:as_json).and_return(answer_1)
         allow(answer_1).to receive(:question).and_return(question)
+        allow(answer_1).to receive(:sort_position).and_return(2)
+        allow(answer_1).to receive(:stem_answers).and_return([])
         allow(answer_1).to receive(:content).and_return('No')
         answer_2 = instance_spy(Answer)
-        allow(answer_2).to receive(:id).and_return(1)
+        allow(answer_2).to receive(:id).and_return(2)
         allow(answer_2).to receive(:as_json).and_return(answer_2)
         allow(answer_2).to receive(:question).and_return(question)
+        allow(answer_2).to receive(:sort_position).and_return(1)
+        allow(answer_2).to receive(:stem_answers).and_return([])
         allow(answer_2).to receive(:content).and_return('Yes')
-        answers = [answer_1, answer_2]
-        answer_representations = answers.reverse.collect do |answer|
+        answer_3 = instance_spy(Answer)
+        allow(answer_3).to receive(:id).and_return(3)
+        allow(answer_3).to receive(:as_json).and_return(answer_3)
+        allow(answer_3).to receive(:question).and_return(question)
+        allow(answer_3).to receive(:sort_position).and_return(3)
+        allow(answer_3).to receive(:stem_answers).and_return([])
+        allow(answer_3).to receive(:content).and_return('Maybe so')
+        answers = [answer_2, answer_1, answer_3]
+        answer_representations = answers.collect do |answer|
           AnswerRepresenter.new(answer).to_hash
         end
         allow(question).to receive(:answers).and_return(answers)
         expect(representation).to include('answers' => answer_representations)
       end
 
-      xit 'can be written' do
+      it 'can be written' do
+        described_class.new(question).from_json({'answers' => [
+          { 'content_html' => 'Yes' }, { 'content_html' => 'No' }, { 'content_html' => 'Maybe so' }
+        ]}.to_json)
+
+        expect(question).to have_received(:answers=)
+                              .with(3.times.map{ a_kind_of(Answer) }) do |answers|
+          expect(answers.first.content).to eq 'Yes'
+          expect(answers.second.content).to eq 'No'
+          expect(answers.third.content).to eq 'Maybe so'
+        end
       end
     end
 

--- a/spec/representers/api/v1/simple_question_representer_spec.rb
+++ b/spec/representers/api/v1/simple_question_representer_spec.rb
@@ -74,33 +74,69 @@ module Api::V1
         expect(representation).to include('stem_html' => stem_representation)
       end
 
-      xit 'can be written' do
+      it 'can be written' do
+        described_class.new(question)
+                       .from_json({'stem_html' => 'Yes, I do!'}.to_json)
+        expect(question.stems.first).to have_received(:content=).with('Yes, I do!')
+      end
+    end
+
+    context 'answer_order_matters' do
+      it 'can be read' do
+        allow(question).to receive(:answer_order_matters).and_return(false)
+        expect(representation).to include('is_answer_order_important' => false)
+      end
+
+      it 'can be written' do
+        described_class.new(question).from_json({'is_answer_order_important' => false}.to_json)
+        expect(question).to have_received(:answer_order_matters=).with(false)
       end
     end
 
     context 'answers' do
       it 'can be read' do
         answer_1 = instance_spy(Answer)
-        allow(answer_1).to receive(:id).and_return(2)
+        allow(answer_1).to receive(:id).and_return(1)
         allow(answer_1).to receive(:as_json).and_return(answer_1)
         allow(answer_1).to receive(:question).and_return(question)
+        allow(answer_1).to receive(:sort_position).and_return(2)
         allow(answer_1).to receive(:stem_answers).and_return([])
         allow(answer_1).to receive(:content).and_return('No')
         answer_2 = instance_spy(Answer)
-        allow(answer_2).to receive(:id).and_return(1)
+        allow(answer_2).to receive(:id).and_return(2)
         allow(answer_2).to receive(:as_json).and_return(answer_2)
         allow(answer_2).to receive(:question).and_return(question)
+        allow(answer_2).to receive(:sort_position).and_return(1)
         allow(answer_2).to receive(:stem_answers).and_return([])
         allow(answer_2).to receive(:content).and_return('Yes')
-        answers = [answer_1, answer_2]
-        answer_representations = answers.reverse.collect do |answer|
+        answer_3 = instance_spy(Answer)
+        allow(answer_3).to receive(:id).and_return(3)
+        allow(answer_3).to receive(:as_json).and_return(answer_3)
+        allow(answer_3).to receive(:question).and_return(question)
+        allow(answer_3).to receive(:sort_position).and_return(3)
+        allow(answer_3).to receive(:stem_answers).and_return([])
+        allow(answer_3).to receive(:content).and_return('Maybe so')
+        answers = [answer_2, answer_1, answer_3]
+        answer_representations = answers.collect do |answer|
           AnswerRepresenter.new(answer).to_hash
         end
         allow(question).to receive(:answers).and_return(answers)
         expect(representation).to include('answers' => answer_representations)
       end
 
-      xit 'can be written' do
+      it 'can be written' do
+        # instance_spy doesn't work here because the Answers being created expect a real Question
+        real_q = FactoryGirl.build :question
+
+        expect(real_q).to receive(:answers=).with(3.times.map{ a_kind_of(Answer) }) do |answers|
+          expect(answers.first.content).to eq 'Yes'
+          expect(answers.second.content).to eq 'No'
+          expect(answers.third.content).to eq 'Maybe so'
+        end
+
+        described_class.new(real_q).from_json({'answers' => [
+          { 'content_html' => 'Yes' }, { 'content_html' => 'No' }, { 'content_html' => 'Maybe so' }
+        ]}.to_json)
       end
     end
 


### PR DESCRIPTION
This PR affects many things, so I would be OK with waiting until Summer...

Once this is merged:

- Existing exercises will have their answers reordered to match the same order as when they were first imported.
- FE should no longer sort answers (PR's will be needed for `exercises-js` and `tutor-js`)
  - Answers will come ordered from BE
  - Order will be preserved through all operations (most importantly, when deriving new versions of questions)
- A boolean flag that says whether or not the answers can be reordered will be added (cannot reorder answers by default)