### PR TITLE
Made the SimpleQuestionRepresenter not explode ...

### DIFF
--- a/app/representers/api/v1/simple_question_representer.rb
+++ b/app/representers/api/v1/simple_question_representer.rb
@@ -79,7 +79,7 @@ module Api::V1
                type: String,
                writeable: true,
                readable: true,
-               getter: lambda { |args| stems.first.stylings.collect{ |s| s.style } },
+               getter: lambda { |args| stems.first.try(:stylings).try(:map, &:style) },
                setter: lambda { |values, args|
                  values.each do |value|
                    styling = stems.first.stylings


### PR DESCRIPTION
 ... when an Exercise has a Question with no Stems