### PR TITLE
Updates to the tag migration

### DIFF
--- a/lib/migrate_tags.rb
+++ b/lib/migrate_tags.rb
@@ -31,7 +31,7 @@ class MigrateTags
       chapter = matches[2]
       section = matches[3]
       lo = matches[4]
-      new_tag tag, "lo:stax-#{book_name}:#{chapter}-#{section}-#{lo}"
+      new_tag tag, "lo:stax-#{book_name}:#{chapter.to_i}-#{section.to_i}-#{lo.to_i}"
     end
 
     aplo_tags = Tag.where{name.like 'apbio-ch%-s%-aplo-%'} # Used by Tutor
@@ -112,6 +112,15 @@ class MigrateTags
     new_tag grasp_check_tag, 'filter-type:grasp-check'
     grasp_check_tag.destroy
 
+    visual_connection_tag = Tag.find_or_create_by(name: 'visual-connection') # Unused
+    new_tag visual_connection_tag, 'filter-type:grasp-check'
+
+    interactive_tag = Tag.find_or_create_by(name: 'interactive') # Unused
+    new_tag interactive_tag, 'filter-type:grasp-check'
+
+    evolution_tag = Tag.find_or_create_by(name: 'evolution') # Unused
+    new_tag evolution_tag, 'filter-type:grasp-check'
+
     old_practice_tag = Tag.find_or_create_by(name: 'os-practice-problems') # Used by Tutor
     new_tag old_practice_tag, 'type:practice'
 
@@ -132,6 +141,9 @@ class MigrateTags
     old_tp_tag = Tag.find_or_create_by(name: 'ost-test-prep') # Unused
     new_tag old_tp_tag, 'type:practice'
     new_tag old_tp_tag, 'filter-type:test-prep'
+
+    old_ap_tp_tag = Tag.find_or_create_by(name: 'ap-test-prep') # Unused
+    new_tag old_ap_tp_tag, 'filter-type:ap-test-prep'
   end
 
   protected

--- a/lib/migrate_tags.rb
+++ b/lib/migrate_tags.rb
@@ -1,9 +1,8 @@
 require 'open-uri'
 
 # Creates new tags for HS questions but does not delete old ones (except for a few unused tags)
-# Does not create new LO tags
-# Migrate LO's and delete old tags after May 30th
-class MigrateHsTagsOne
+# Also changes all cnxmod tags to context-cnxmod
+class MigrateTags
 
   lev_routine transaction: :no_transaction
 
@@ -20,9 +19,28 @@ class MigrateHsTagsOne
       map_collection(hash['tree'], cnx_id_map[book_name])
     end
 
-    # LO tags (unchanged for now)
+    # Cnxmod tags
+    cnxmod_tags = Tag.where{name.like 'cnxmod:%'}
+    cnxmod_tags.each{ |tag| tag.update_attribute :name, "context-#{tag.name}" }
+
+    # LO tags
     lo_tags = Tag.where{name.like_any ['k12phys-ch%-s%-lo%', 'apbio-ch%-s%-lo%']} # Used by Tutor
+    lo_tags.each do |tag|
+      matches = /\A(\w+)-ch(\d+)-s(\d+)-lo(\d+)\z/.match tag.name
+      book_name = matches[1]
+      chapter = matches[2]
+      section = matches[3]
+      lo = matches[4]
+      new_tag tag, "lo:stax-#{book_name}:#{chapter}-#{section}-#{lo}"
+    end
+
     aplo_tags = Tag.where{name.like 'apbio-ch%-s%-aplo-%'} # Used by Tutor
+    aplo_tags.each do |tag|
+      matches = /\Aapbio-ch\d+-s\d+-aplo-([\w-]+)\z/.match tag.name
+      lo = matches[1]
+      new_tag tag, "lo:aplo-bio:#{lo}"
+    end
+
     all_lo_tags = lo_tags + aplo_tags
 
     # ID tags
@@ -44,7 +62,7 @@ class MigrateHsTagsOne
       chapter = matches[2]
       section = matches[3]
       uuid = cnx_id_map[book_name][chapter.to_i][section.to_i]
-      new_tag tag, "cnxmod:#{uuid}"
+      new_tag tag, "context-cnxmod:#{uuid}"
     end
 
     book_tags = Tag.where(name: ['k12phys', 'apbio']) # Unused

--- a/spec/lib/migrate_tags_spec.rb
+++ b/spec/lib/migrate_tags_spec.rb
@@ -1,18 +1,22 @@
 require 'rails_helper'
-require 'migrate_hs_tags_one'
+require 'migrate_tags'
 
-RSpec.describe MigrateHsTagsOne do
+RSpec.describe MigrateTags do
   context 'high school' do
-    it 'does not migrate LO\'s' do
+    it 'assigns new LO tags' do
       ex = FactoryGirl.create :exercise, tags: ['k12phys-ch01-s01-lo01']
       described_class.call
-      expect{ described_class.call }.not_to change{ ex.reload.tags }
+      tag_names = ex.reload.tags.map(&:name)
+      expect(tag_names).to include('k12phys-ch01-s01-lo01')
+      expect(tag_names).to include('lo:stax-k12phys:1-1-1')
     end
 
-    it 'does not migrate APLO\'s' do
+    it 'assigns new APLO tags' do
       ex = FactoryGirl.create :exercise, tags: ['apbio-ch01-s01-aplo-1-1']
       described_class.call
-      expect{ described_class.call }.not_to change{ ex.reload.tags }
+      tag_names = ex.reload.tags.map(&:name)
+      expect(tag_names).to include('apbio-ch01-s01-aplo-1-1')
+      expect(tag_names).to include('lo:aplo-bio:1-1')
     end
 
     it 'does not migrate chapter tags' do
@@ -34,7 +38,7 @@ RSpec.describe MigrateHsTagsOne do
       described_class.call
       tag_names = ex.reload.tags.map(&:name)
       expect(tag_names).to include('k12phys-ch01-s01')
-      expect(tag_names).to include('cnxmod:17f6ff53-2d92-4669-acdd-9a958ea7fd0a')
+      expect(tag_names).to include('context-cnxmod:17f6ff53-2d92-4669-acdd-9a958ea7fd0a')
     end
 
     it 'migrates book tags correctly' do
@@ -159,6 +163,38 @@ RSpec.describe MigrateHsTagsOne do
       tag_names = ex.reload.tags.map(&:name)
       expect(tag_names).not_to include('grasp-check')
       expect(tag_names).to include('filter-type:grasp-check')
+    end
+
+    it 'assigns new tags for visual-connection' do
+      ex = FactoryGirl.create :exercise, tags: ['visual-connection']
+      described_class.call
+      tag_names = ex.reload.tags.map(&:name)
+      expect(tag_names).to include('visual-connection')
+      expect(tag_names).to include('filter-type:grasp-check')
+    end
+
+    it 'assigns new tags for interactive' do
+      ex = FactoryGirl.create :exercise, tags: ['interactive']
+      described_class.call
+      tag_names = ex.reload.tags.map(&:name)
+      expect(tag_names).to include('interactive')
+      expect(tag_names).to include('filter-type:grasp-check')
+    end
+
+    it 'assigns new tags for evolution' do
+      ex = FactoryGirl.create :exercise, tags: ['evolution']
+      described_class.call
+      tag_names = ex.reload.tags.map(&:name)
+      expect(tag_names).to include('evolution')
+      expect(tag_names).to include('filter-type:grasp-check')
+    end
+
+    it 'assigns new tags for ap-test-prep' do
+      ex = FactoryGirl.create :exercise, tags: ['ap-test-prep']
+      described_class.call
+      tag_names = ex.reload.tags.map(&:name)
+      expect(tag_names).to include('ap-test-prep')
+      expect(tag_names).to include('filter-type:ap-test-prep')
     end
   end
 


### PR DESCRIPTION
- Changed cnxmod tags to context-cnxmod
- Added new style tags for the LO's
- filter-type:grasp-check tags for visual-connection, interactive, evolution
- filter-type:ap-test-prep for ap-test-prep