### PR TITLE
Add @latest specifier for exercises

### DIFF
--- a/lib/publishable/active_record.rb
+++ b/lib/publishable/active_record.rb
@@ -24,11 +24,12 @@ module Publishable
               relation = relation.where{ publication.published_at != nil }
             elsif version == 'draft' || version == 'd'
               pub_conditions[:published_at] = nil
-            else
+            elsif version != 'latest'
               pub_conditions[:version] = version
             end
             relation.where(publication: pub_conditions)
-                    .order{[publication.number.asc, publication.version.desc]}
+              .order{[publication.number.asc, publication.version.desc]}
+
           }
 
           # http://stackoverflow.com/a/7745635

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -38,8 +38,6 @@ module Api::V1
                                               username: "doejane"
         @john_doe.account.reload
         @jane_doe.account.reload
-
-        @users_count = User.count
       end
 
       it "returns no results if the maximum number of results is exceeded" do
@@ -47,7 +45,7 @@ module Api::V1
         expect(response).to have_http_status(:success)
 
         expected_response = {
-          total_count: @users_count,
+          total_count: User.count,
           items: []
         }.to_json
 


### PR DESCRIPTION
Previously the FE would always append @draft when fetching an exercise, but doesn't actually need to create a draft every time, and it causes errors when the exercise originates from a vocab term.

This adds a `@latest` to just fetch the highest version.