### PR TITLE
Vocab term editing improvements

### DIFF
--- a/app/models/vocab_term.rb
+++ b/app/models/vocab_term.rb
@@ -77,7 +77,7 @@ class VocabTerm < ActiveRecord::Base
 
   def new_version
     nv = deep_clone include: NEW_VERSION_DUPED_ASSOCIATIONS, use_dictionary: true
-    nv.exercises = exercises.map(&:new_version)
+    nv.exercises = latest_exercises.map(&:new_version)
     nv.publication.version = nv.publication.version + 1
     nv.publication.published_at = nil
     nv.publication.yanked_at = nil
@@ -184,7 +184,7 @@ class VocabTerm < ActiveRecord::Base
       stem.stem_answers = stem_answers
     end
 
-    self.exercises += vocab_exercises
+    self.exercises = (exercises + vocab_exercises).uniq
   end
 
 end

--- a/db/migrate/20160606214816_add_default_to_vocab_terms_definition.rb
+++ b/db/migrate/20160606214816_add_default_to_vocab_terms_definition.rb
@@ -1,0 +1,5 @@
+class AddDefaultToVocabTermsDefinition < ActiveRecord::Migration
+  def change
+    change_column_default :vocab_terms, :definition, ''
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160425191417) do
+ActiveRecord::Schema.define(version: 20160606214816) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -619,7 +619,7 @@ ActiveRecord::Schema.define(version: 20160425191417) do
 
   create_table "vocab_terms", force: :cascade do |t|
     t.string   "name",                             null: false
-    t.string   "definition",                       null: false
+    t.string   "definition",          default: "", null: false
     t.string   "distractor_literals", default: [], null: false, array: true
     t.datetime "created_at",                       null: false
     t.datetime "updated_at",                       null: false

--- a/spec/models/vocab_term_spec.rb
+++ b/spec/models/vocab_term_spec.rb
@@ -10,7 +10,25 @@ RSpec.describe VocabTerm, type: :model do
   it { is_expected.to have_many(:list_vocab_terms).dependent(:destroy) }
 
   it { is_expected.to validate_presence_of(:name) }
-  it { is_expected.to validate_presence_of(:definition) }
+
+  it 'saves even if the definition is blank' do
+    vocab_term.definition = ''
+    vocab_term.save!
+
+    vt = VocabTerm.new(name: 'test')
+    vt.save!
+    expect(vt.definition).to eq ''
+  end
+
+  it 'ensures that it has a definition before publication' do
+    vocab_term.publication.publish
+    vocab_term.before_publication
+    expect(vocab_term.errors).to be_empty
+
+    vocab_term.definition = ''
+    vocab_term.before_publication
+    expect(vocab_term.errors[:base]).to include('must have a definition')
+  end
 
   it 'ensures that it has at least 1 distractor before publication' do
     vocab_term.publication.publish

--- a/spec/models/vocab_term_spec.rb
+++ b/spec/models/vocab_term_spec.rb
@@ -54,6 +54,16 @@ RSpec.describe VocabTerm, type: :model do
     vocab_term.exercises.each{ |exercise| expect(exercise).to be_is_published }
   end
 
+  it 'does not create extra versions of exercises when creating a new version' do
+    vocab_term.exercises.first.publication.publish.save!
+    vocab_term.exercises << vocab_term.exercises.first.new_version
+    expect(vocab_term.exercises.size).to eq 2
+    vocab_term.publication.publish.save!
+    vocab_term.exercises.each{ |exercise| expect(exercise).to be_is_published }
+    new_version = vocab_term.new_version
+    expect(new_version.exercises.size).to eq 1
+  end
+
   it 'updates distracted_term exercises when published' do
     distractor_term = vocab_term.vocab_distractors.first.distractor_term
     distractor_term.distractor_literals = ['Required for publication']


### PR DESCRIPTION
- Prevent vocab term new versions from creating a ton of duplicate exercises
- Allow vocab terms to save (but not publish) with a blank definition