### PR TITLE
Whitelist openstax.org as iframe source

### DIFF
--- a/config/initializers/user_html.rb
+++ b/config/initializers/user_html.rb
@@ -4,6 +4,7 @@ EMBED_URL_REGEXES = [
   /\A(?:https?:)?\/\/(?:www\.)?youtube(?:-nocookie)?\.com\//,
   /\A(?:https?:)?\/\/(?:www\.)?khanacademy\.org\//,
   /\A(?:https?:)?\/\/(?:[\w-]+\.)?cnx\.org\//,
+  /\A(?:https?:)?\/\/(?:[\w-]+\.)?openstax\.org\//,
   /\A(?:https?:)?\/\/phet\.colorado\.edu\//
 ]
 


### PR DESCRIPTION
Per @openstaxalina this is needed to use shortcode redirect sources 