### PR TITLE
switch from coveralls to codecov

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,6 @@
+comment:
+  layout: "header, diff, changes, uncovered, tree"
+  behavior: default
+
+# To Turn off comments completely:
+# comment: false

--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,6 +1,111 @@
-comment:
-  layout: "header, diff, changes, uncovered, tree"
-  behavior: default
+# codecov:
+#   url: "string"        # [enterprise] your self-hosted Codecov endpoint
+#                        # ex. https://codecov.company.com
+#   slug: "owner/repo"   # [enterprise] the project's name when using the global upload tokens
+#   branch: master       # the branch to show by default, inherited from your git repository settings
+#                        # ex. master, stable or release
+#                        # default: the default branch in git/mercurial
+#   bot: username        # the username that will consume any oauth requests
+#                        # must have previously logged into Codecov
+#   ci:                  # [advanced] a list of custom CI domains
+#     - "ci.custom.com"
+#   notify:              # [advanced] usage only
+#     after_n_builds: 5  # how many build to wait for before submitting notifications
+#                        # therefore skipping status checks
+#     countdown: 50      # number of seconds to wait before checking CI status
+#     delay: 100         # number of seconds between each CI status check
 
-# To Turn off comments completely:
-# comment: false
+coverage:
+  # precision: 2         # how many decimal places to display in the UI: 0 <= value <= 4
+  # round: down          # how coverage is rounded: down/up/nearest
+  # range: 50...100      # custom range of coverage colors from red -> yellow -> green
+
+  # notify:
+  #   irc:
+  #     default:                        # -> see "sections" below
+  #       server: "chat.freenode.net"   #*S the domain of the irc server
+  #       branches: null                # -> see "branch patterns" below
+  #       threshold: null               # -> see "threshold" below
+  #       message: "template string"    # [advanced] -> see "customized message" below
+
+  #   slack:
+  #     default:                        # -> see "sections" below
+  #       url: "https://hooks.slack.com/..."  #*S unique Slack notifications url
+  #       branches: null                # -> see "branch patterns" below
+  #       threshold: null               # -> see "threshold" below
+  #       attachments: "sunburst, diff" # list of attachments to include in notification
+  #       message: "template string"    # [advanced] -> see "customized message" below
+
+  #   hipchat:
+  #     default:                        # -> see "sections" below
+  #       url: "https://team.hipchat.com/.." #*S your HipChat room
+  #       notify: true                  # boolean: toggle the messages "notify" feature (true is noisy)
+  #       branches: null                # -> see "branch patterns" below
+  #       card: true                    # boolean: enable or disable including extra details
+  #       threshold: null               # -> see "threshold" below
+  #       message: "template string"    # [advanced] -> see "customized message" below
+
+  #   gitter:
+  #     default:                        # -> see "sections" below
+  #       url: "https://webhooks.gitter.im/..."  #*S unique Gitter notifications url
+  #       branches: null                # -> see "branch patterns" below
+  #       threshold: null               # -> see "threshold" below
+  #       message: "template string"    # [advanced] -> see "customized message" below
+
+  #   webhook:
+  #     default:                        # -> see "sections" below
+  #       url: "https://domain.com"     #*S custom domain endpoint to post data to
+  #       branches: null                # -> see "branch patterns" below
+  #       threshold: null               # -> see "threshold" below
+
+  status:
+    project:                   # measuring the overall project coverage
+      default:                 # context, you can create multiple ones with custom titles
+        # enabled: yes           # must be yes|true to enable this status
+        target: 90%              # specify the target coverage for each commit status
+        #                        #   option: "auto" (must increase from parent commit or pull request base)
+        #                        #   option: "X%" a static target percentage to hit
+        # branches:              # -> see "branch patterns" below
+        threshold: 1%            # allowed to drop X% and still result in a "success" commit status
+        # if_no_uploads: error   # will post commit status of "error" if no coverage reports we uploaded
+        #                        # options: success, error, failure
+        # if_not_found: success  # if parent is not found report status as success, error, or failure
+        # if_ci_failed: error    # if ci fails report status as success, error, or failure
+
+    patch:                     # pull requests only: this commit status will measure the
+                               # entire pull requests Coverage Diff. Checking if the lines
+                               # adjusted are covered at least X%.
+      default:
+        # enabled: yes             # must be yes|true to enable this status
+        target: 60%                 # specify the target "X%" coverage to hit
+        # branches: null           # -> see "branch patterns" below
+        threshold: 2%              # allowed to drop X% and still result in a "success" commit status
+        # if_no_uploads: error     # will post commit status of "error" if no coverage reports we uploaded
+        #                          # options: success, error, failure
+        # if_not_found: success
+        # if_ci_failed: error
+
+    # changes:                   # if there are any unexpected changes in coverage
+    #   default:
+    #     enabled: yes             # must be yes|true to enable this status
+    #     branches: null           # -> see "branch patterns" below
+    #     if_no_uploads: error
+    #     if_not_found: success
+    #     if_ci_failed: error
+
+
+  # ignore:          # files and folders that will be removed during processing
+  #   - "tests/*"
+  #   - "demo/*.rb"
+
+  # fixes:           # [advanced] in rare cases the report tree is invalid, specify adjustments here
+  #   - "old_path::new_path"
+
+comment: false  # to disable comments
+# comment:
+#   layout: "header, diff, changes, sunburst, suggestions, tree"
+#   branches: null           # -> see "branch patterns" below
+#   behavior: default        # option: "default" posts once then update, posts new if delete
+#                            # option: "once"    post once then updates, if deleted do not post new
+#                            # option: "new"     delete old, post new
+#                            # option: "spammy"  post new

--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,7 @@ rspec.failures
 # Ignore brakeman reports
 brakeman.html
 
-# Ignore coveralls reports
+# Ignore coverage reports
 coverage/*
 
 # Ignore ERD diagrams

--- a/Gemfile
+++ b/Gemfile
@@ -202,8 +202,8 @@ group :test do
   # Code Climate integration
   gem "codeclimate-test-reporter", require: false
 
-  # Coveralls integration
-  gem 'coveralls', require: false
+  # Codecov integration
+  gem 'codecov', require: false
 
   # Test after-commit hooks
   gem 'test_after_commit'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,6 +85,10 @@ GEM
     chunky_png (1.3.4)
     codeclimate-test-reporter (0.4.7)
       simplecov (>= 0.7.1, < 1.0.0)
+    codecov (0.1.9)
+      json
+      simplecov
+      url
     coffee-rails (4.1.0)
       coffee-script (>= 2.2.0)
       railties (>= 4.0.0, < 5.0)
@@ -114,12 +118,6 @@ GEM
       compass (~> 1.0.0)
       sass-rails (<= 5.0.1)
       sprockets (< 2.13)
-    coveralls (0.7.12)
-      multi_json (~> 1.10)
-      rest-client (>= 1.6.8, < 2)
-      simplecov (~> 0.9.1)
-      term-ansicolor (~> 1.3)
-      thor (~> 0.19.1)
     crass (1.0.2)
     daemons (1.2.2)
     database_cleaner (1.4.1)
@@ -131,8 +129,6 @@ GEM
     diff-lcs (1.2.5)
     diffy (3.1.0)
     docile (1.1.5)
-    domain_name (0.5.23)
-      unf (>= 0.0.5, < 1.0.0)
     doorkeeper (3.1.0)
       railties (>= 3.2)
     eco (1.0.0)
@@ -272,8 +268,6 @@ GEM
     hashie (3.4.4)
     highline (1.6.21)
     hike (1.2.3)
-    http-cookie (1.0.2)
-      domain_name (~> 0.5)
     httparty (0.13.7)
       json (~> 1.8)
       multi_xml (>= 0.5.2)
@@ -325,7 +319,6 @@ GEM
     net-scp (1.2.1)
       net-ssh (>= 2.6.5)
     net-ssh (2.9.2)
-    netrc (0.10.3)
     newrelic_rpm (3.11.1.284)
     nifty-generators (0.4.6)
     nokogiri (1.6.8.1)
@@ -447,10 +440,6 @@ GEM
       uber (~> 0.0.15)
     responders (2.2.0)
       railties (>= 4.2.0, < 5.1)
-    rest-client (1.8.0)
-      http-cookie (>= 1.0.2, < 2.0)
-      mime-types (>= 1.16, < 3.0)
-      netrc (~> 0.7)
     rinku (1.7.3)
     roar (1.0.3)
       representable (>= 2.0.1, <= 3.0.0)
@@ -530,8 +519,6 @@ GEM
       activerecord (>= 3.0)
       activesupport (>= 3.0)
       polyamorous (~> 1.1.0)
-    term-ansicolor (1.3.0)
-      tins (~> 1.0)
     terminal-table (1.4.5)
     test_after_commit (0.4.1)
       activerecord (>= 3.2)
@@ -549,7 +536,6 @@ GEM
     thread_safe (0.3.5)
     tilt (1.4.1)
     timecop (0.7.3)
-    tins (1.3.5)
     transaction_isolation (1.0.3)
       activerecord (>= 3.0.11)
     transaction_retry (1.0.2)
@@ -563,9 +549,6 @@ GEM
     uglifier (2.7.1)
       execjs (>= 0.3.0)
       json (>= 1.8.0)
-    unf (0.1.4)
-      unf_ext
-    unf_ext (0.0.6)
     unicorn (4.8.3)
       kgio (~> 2.6)
       rack
@@ -573,6 +556,7 @@ GEM
     unicorn-worker-killer (0.4.3)
       get_process_mem (~> 0)
       unicorn (~> 4)
+    url (0.3.2)
     web-console (2.1.2)
       activemodel (>= 4.0)
       binding_of_caller (>= 0.7.2)
@@ -598,11 +582,11 @@ DEPENDENCIES
   charlock_holmes
   cheat
   codeclimate-test-reporter
+  codecov
   coffee-rails (~> 4.1.0)
   coffee-rails-source-maps
   commontator
   compass-rails
-  coveralls
   database_cleaner
   deep_cloneable
   doorkeeper (~> 3.1.0)
@@ -663,4 +647,4 @@ DEPENDENCIES
   whenever
 
 BUNDLED WITH
-   1.13.6
+   1.14.6

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ OpenStax Exercises
 
 [![Build Status](https://travis-ci.org/openstax/exercises.svg?branch=master)](https://travis-ci.org/openstax/exercises)
 [![Code Climate](https://codeclimate.com/github/openstax/exercises.png)](https://codeclimate.com/github/openstax/exercises)
-[![Coverage Status](https://img.shields.io/coveralls/openstax/exercises.svg)](https://coveralls.io/r/openstax/exercises)
+[![Coverage Status](https://img.shields.io/codecov/c/github/openstax/exercises.svg)](https://codecov.io/gh/openstax/exercises)
 
 OpenStax Exercises is an open homework and test question bank, where questions are written
 by the community and access is free. Successor to Quadbase.

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,11 +1,8 @@
 require 'simplecov'
-require 'coveralls'
+require 'codecov'
 require 'parallel_tests'
 
-SimpleCov.formatter = SimpleCov::Formatter::MultiFormatter[
-  SimpleCov::Formatter::HTMLFormatter,
-  Coveralls::SimpleCov::Formatter
-] if ParallelTests.first_process?
+SimpleCov.formatter = SimpleCov::Formatter::Codecov
 
 SimpleCov.at_exit do
   ParallelTests.wait_for_other_processes_to_finish if ParallelTests.first_process?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -2,12 +2,7 @@ require 'simplecov'
 require 'codecov'
 require 'parallel_tests'
 
-SimpleCov.formatter = SimpleCov::Formatter::Codecov
-
-SimpleCov.at_exit do
-  ParallelTests.wait_for_other_processes_to_finish if ParallelTests.first_process?
-  SimpleCov.result.format!
-end
+SimpleCov.formatter = SimpleCov::Formatter::Codecov if ENV['CI'] == 'true'
 
 SimpleCov.start 'rails'
 


### PR DESCRIPTION
As part of https://github.com/openstax/napkin-notes/issues/68 this switches from coveralls to codecov.

I was not sure about a couple things but took some defaults:

- When should coveralls make comments on the PR and what should be included
- I used this recommendation from codecov.io: https://github.com/codecov/example-ruby

# Problems

While running `eval "$(rbenv init -)" && gem install bundler && bundle install` I got the following error so I was unable to update the `Gemfile.lock` and I do not know how to proceed.

```
checking for sys/queue.h... yes
checking for clock_gettime()... no
checking for gethrtime()... no
creating Makefile

make "DESTDIR=" clean

make "DESTDIR="
compiling binder.cpp
In file included from binder.cpp:20:
./project.h:116:10: fatal error: 'openssl/ssl.h' file not found
#include <openssl/ssl.h>
         ^
1 error generated.
make: *** [binder.o] Error 1

make failed, exit code 2

Gem files will remain installed in
/Users/.../.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/gems/eventmachine-1.0.7
for inspection.
Results logged to
/Users/.../.rbenv/versions/2.2.3/lib/ruby/gems/2.2.0/extensions/x86_64-darwin-15/2.2.0-static/eventmachine-1.0.7/gem_make.out

An error occurred while installing eventmachine (1.0.7), and Bundler
cannot continue.
Make sure that `gem install eventmachine -v '1.0.7'` succeeds before
bundling.
```