### PR TITLE
Memoize calls to can_view_solutions? inside representers

### DIFF
--- a/app/representers/api/v1/exercise_representer.rb
+++ b/app/representers/api/v1/exercise_representer.rb
@@ -3,7 +3,12 @@ module Api::V1
 
     include Roar::JSON
 
-    can_view_solutions_proc = ->(user_options:, **) { can_view_solutions?(user_options[:user]) }
+    can_view_solutions_proc = ->(user_options:, **) do
+      user_options[:can_view_solutions] ||=
+        user_options.has_key?(:can_view_solutions) ?
+          user_options[:can_view_solutions] :
+          can_view_solutions?(user_options[:user])
+    end
 
     # Attachments may (for a while) contain collaborator solution attachments, so
     # only show them to those who can see solutions

--- a/app/representers/api/v1/question_representer.rb
+++ b/app/representers/api/v1/question_representer.rb
@@ -4,7 +4,10 @@ module Api::V1
     include Roar::JSON
 
     can_view_solutions_proc = ->(user_options:, **) do
-      exercise.can_view_solutions?(user_options[:user])
+      user_options[:can_view_solutions] ||=
+        user_options.has_key?(:can_view_solutions) ?
+          user_options[:can_view_solutions] :
+          exercise.can_view_solutions?(user_options[:user])
     end
 
     property :id,

--- a/app/representers/api/v1/simple_answer_representer.rb
+++ b/app/representers/api/v1/simple_answer_representer.rb
@@ -4,7 +4,10 @@ module Api::V1
     include Roar::JSON
 
     can_view_solutions_proc = ->(user_options:, **) do
-      question.exercise.can_view_solutions?(user_options[:user])
+      user_options[:can_view_solutions] ||=
+        user_options.has_key?(:can_view_solutions) ?
+          user_options[:can_view_solutions] :
+          question.exercise.can_view_solutions?(user_options[:user])
     end
 
     property :id,

--- a/app/representers/api/v1/simple_question_representer.rb
+++ b/app/representers/api/v1/simple_question_representer.rb
@@ -4,7 +4,10 @@ module Api::V1
     include Roar::JSON
 
     can_view_solutions_proc = ->(user_options:, **) do
-      exercise.can_view_solutions?(user_options[:user])
+      user_options[:can_view_solutions] ||=
+        user_options.has_key?(:can_view_solutions) ?
+          user_options[:can_view_solutions] :
+          exercise.can_view_solutions?(user_options[:user])
     end
 
     property :id,

--- a/app/representers/api/v1/stem_answer_representer.rb
+++ b/app/representers/api/v1/stem_answer_representer.rb
@@ -4,7 +4,10 @@ module Api::V1
     include Roar::JSON
 
     can_view_solutions_proc = ->(user_options:, **) do
-      stem.question.exercise.can_view_solutions?(user_options[:user])
+      user_options[:can_view_solutions] ||=
+        user_options.has_key?(:can_view_solutions) ?
+          user_options[:can_view_solutions] :
+          stem.question.exercise.can_view_solutions?(user_options[:user])
     end
 
     property :answer_id,

--- a/spec/representers/api/v1/exercise_representer_spec.rb
+++ b/spec/representers/api/v1/exercise_representer_spec.rb
@@ -114,5 +114,16 @@ module Api::V1
       end
     end
 
+    context "too many can_view_solutions? queries" do
+      let!(:real_exercise) { FactoryGirl.create(:exercise, questions_count: 1)}
+      let!(:user) { FactoryGirl.create :user }
+
+      it 'only calls can_view_solutions? one time' do
+        expect_any_instance_of(Exercise).to receive(:can_view_solutions?).once.and_call_original
+        described_class.new(real_exercise).to_hash(user_options: {user: user})
+      end
+
+    end
+
   end
 end


### PR DESCRIPTION
`can_view_solutions?` is called a lot (on the same exercise with the same user) when rendering an exercise to JSON.  This PR memoizes its value.  In a production example, the method was being called 12 times; this reduces it to once.