### PR TITLE
Fix double entries in formats array and weirdness with setting the formats (and other arrays)

### DIFF
--- a/app/controllers/api/v1/exercises_controller.rb
+++ b/app/controllers/api/v1/exercises_controller.rb
@@ -66,7 +66,7 @@ module Api::V1
       The string is a comma-separated list of fields with an optional sort direction.
       The sort will be performed in the order the fields are given.
       The fields can be one of #{
-        SearchExercises::SORTABLE_FIELDS.keys.map{ |sf| "`"+sf+"`" }.join(', ')
+        SearchExercises::SORTABLE_FIELDS.keys.map { |sf| "`"+sf+"`" }.join(', ')
       }.
       Sort directions can either be `ASC` for an ascending sort, or `DESC` for a descending sort.
       If not provided, an ascending sort is assumed.

--- a/app/controllers/api/v1/lists_controller.rb_
+++ b/app/controllers/api/v1/lists_controller.rb_
@@ -38,7 +38,7 @@ module Api::V1
       is a comma-separated list of fields with an optional sort direction. The
       sort will be performed in the order the fields are given.
       The fields can be one of #{
-        SearchLists::SORTABLE_FIELDS.collect{|sf| "`"+sf+"`"}.join(', ')
+        SearchLists::SORTABLE_FIELDS.map {|sf| "`"+sf+"`"}.join(', ')
       }.
       Sort directions can either be `ASC` for an ascending sort, or `DESC` for
       a descending sort. If not provided, an ascending sort is assumed. Sort

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -70,7 +70,7 @@ module Api::V1
       is a comma-separated list of fields with an optional sort direction. The
       sort will be performed in the order the fields are given.
       The fields can be one of #{
-        OpenStax::Accounts::SearchLocalAccounts::SORTABLE_FIELDS.keys.map{|sf| "`"+sf+"`"}
+        OpenStax::Accounts::SearchLocalAccounts::SORTABLE_FIELDS.keys.map {|sf| "`"+sf+"`"}
                                                                      .join(', ')
       }.
       Sort directions can either be `ASC` for

--- a/app/controllers/api/v1/vocab_terms_controller.rb
+++ b/app/controllers/api/v1/vocab_terms_controller.rb
@@ -66,7 +66,7 @@ module Api::V1
       is a comma-separated list of fields with an optional sort direction. The
       sort will be performed in the order the fields are given.
       The fields can be one of #{
-        SearchVocabTerms::SORTABLE_FIELDS.keys.map{|sf| "`"+sf+"`"}.join(', ')
+        SearchVocabTerms::SORTABLE_FIELDS.keys.map {|sf| "`"+sf+"`"}.join(', ')
       }.
       Sort directions can either be `ASC` for
       an ascending sort, or `DESC` for a

--- a/app/handlers/admin/users_search.rb
+++ b/app/handlers/admin/users_search.rb
@@ -30,7 +30,7 @@ module Admin
         prefix = ''
       end
       names = (search_params.query || '').split(/\s/)
-      query = names.map{|name| "#{prefix}#{name}"}.join(' ').to_s
+      query = names.map {|name| "#{prefix}#{name}"}.join(' ').to_s
 
       run(:search_users, query)
     end

--- a/app/models/attachment.rb
+++ b/app/models/attachment.rb
@@ -22,7 +22,7 @@ class Attachment < ActiveRecord::Base
 
   def unique_asset
     return if asset.nil? || parent.nil?
-    return unless Attachment.where{(id != my{id}) & \
+    return unless Attachment.where {(id != my{id}) & \
                                    (parent == my{parent}) & \
                                    (asset == my{asset.identifier})}.exists?
     errors.add(:asset, 'has already been associated with this resource')

--- a/app/models/combo_choice.rb
+++ b/app/models/combo_choice.rb
@@ -5,6 +5,7 @@ class ComboChoice < ActiveRecord::Base
   has_many :combo_choice_answers, dependent: :destroy
 
   validates :stem, presence: true
-  validates :correctness, presence: true, numericality: true
+  validates :correctness, presence: true, numericality: { greater_than_or_equal_to: 0.0,
+                                                          less_than_or_equal_to: 1.0 }
 
 end

--- a/app/models/community_solution.rb
+++ b/app/models/community_solution.rb
@@ -31,7 +31,7 @@ class CommunitySolution < ActiveRecord::Base
     user_id = user.id
 
     joins{publication.authors.outer}
-      .joins{publication.copyright_holders.outer}
-      .where{ (authors.user_id == user_id) | (copyright_holders.user_id == user_id) }
+      .joins {publication.copyright_holders.outer}
+      .where { (authors.user_id == user_id) | (copyright_holders.user_id == user_id) }
   }
 end

--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -115,9 +115,11 @@ class Exercise < ActiveRecord::Base
   end
 
   def can_view_solutions?(user)
-    return false if user.nil?          # Not given
-    return true if new_record?         # Create
+    return false if user.nil?          # User not given
+    return true if new_record?         # Exercise being created
+
     user = user.human_user if user.is_a?(OpenStax::Api::ApiUser)
+
     # Remove the entry below when apps are properly configured as ListReaders
     return true if user.nil?           # Application user
     return false if user.is_anonymous? # Anonymous user

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -162,6 +162,14 @@ class Publication < ActiveRecord::Base
     is_published? && !is_embargoed? && !is_yanked?
   end
 
+  def is_latest?
+    klass = self.class
+
+    !klass.where(publication_group_id: publication_group_id)
+          .where(klass.arel_table[:version].gt version)
+          .exists?
+  end
+
   def collaborators(preload: nil)
     preload = preload.nil? ? :user : { user: preload }
 

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -75,7 +75,7 @@ class Publication < ActiveRecord::Base
       else
         wheres & (version == vv)
       end
-    end.order{[publication_group.number.asc, version.desc]}
+    end.order {[publication_group.number.asc, version.desc]}
   }
 
   scope :visible_for, ->(user) {
@@ -139,7 +139,7 @@ class Publication < ActiveRecord::Base
           (newer_publication.version > ~version)
         end
         .outer
-    end.where{ newer_publication.id == nil }
+    end.where { newer_publication.id == nil }
   }
 
   def uid

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -10,7 +10,7 @@ class Tag < ActiveRecord::Base
     remaining_tags = [tags].flatten.compact
 
     # Get Tag objects in the given array
-    result = remaining_tags.select{ |tag| tag.is_a?(Tag) }
+    result = remaining_tags.select { |tag| tag.is_a?(Tag) }
     remaining_tags = (remaining_tags - result).map do |tag|
       sanitized_name = tag.to_s.gsub(/[^\w:#]+/, '-').gsub(/(?:\A-|-\z)/, '')
       sanitized_name unless sanitized_name.blank?

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -22,7 +22,7 @@ class Tag < ActiveRecord::Base
     remaining_tags -= db_result.map(&:name)
 
     # Initialize remaining Tag objects
-    result + remaining_tags.map{ |tag| Tag.new(name: tag) }
+    result + remaining_tags.map { |tag| Tag.new(name: tag) }
   end
 
   def to_s

--- a/app/models/vocab_term.rb
+++ b/app/models/vocab_term.rb
@@ -126,8 +126,8 @@ class VocabTerm < ActiveRecord::Base
   def after_publication
     last_def = VocabTerm.joins(publication: :publication_group)
                         .where(publication: {publication_group: {number: number}})
-                        .where{id != my{id}}
-                        .order{publication.version.desc}
+                        .where {id != my{id}}
+                        .order {publication.version.desc}
                         .limit(1)
                         .pluck(:definition)
     return if definition == last_def
@@ -137,7 +137,7 @@ class VocabTerm < ActiveRecord::Base
     VocabTerm.joins(:vocab_distractors)
              .where(vocab_distractors: { distractor_publication_group_id: pg_id })
              .latest(scope: VocabTerm.all)
-             .each{ |vt| vt.build_or_update_vocab_exercises_if_latest(published_at) }
+             .each { |vt| vt.build_or_update_vocab_exercises_if_latest(published_at) }
   end
 
   def build_or_update_vocab_exercises_if_latest(publication_time = publication.published_at)

--- a/app/representers/api/v1/combo_choice_answer_representer.rb
+++ b/app/representers/api/v1/combo_choice_answer_representer.rb
@@ -8,7 +8,7 @@ module Api::V1
              writeable: true,
              readable: true,
              setter: ->(input:, **) do
-               self.answer = question.answers.find{ |ans| (ans.id || ans.temp_id) == input }
+               self.answer = question.answers.find { |ans| (ans.id || ans.temp_id) == input }
              end,
              schema_info: {
                required: true

--- a/app/representers/api/v1/combo_choice_representer.rb
+++ b/app/representers/api/v1/combo_choice_representer.rb
@@ -8,6 +8,7 @@ module Api::V1
                representer: ComboChoiceAnswerRepresenter,
                writeable: true,
                readable: true,
+               setter: AR_COLLECTION_SETTER,
                schema_info: {
                  required: true
                }

--- a/app/representers/api/v1/exercise_representer.rb
+++ b/app/representers/api/v1/exercise_representer.rb
@@ -4,10 +4,10 @@ module Api::V1
     include Roar::JSON
 
     can_view_solutions_proc = ->(user_options:, **) do
-      user_options[:can_view_solutions] ||=
-        user_options.has_key?(:can_view_solutions) ?
-          user_options[:can_view_solutions] :
-          can_view_solutions?(user_options[:user])
+      user_options[:can_view_solutions] = can_view_solutions?(user_options[:user]) \
+        if user_options[:can_view_solutions].nil?
+
+      user_options[:can_view_solutions]
     end
 
     # Attachments may (for a while) contain collaborator solution attachments, so
@@ -28,7 +28,7 @@ module Api::V1
              type: Integer,
              writeable: false,
              readable: true,
-             getter: ->(*) { vocab_term.try(:uid) },
+             getter: ->(*) { vocab_term.try!(:uid) },
              if: can_view_solutions_proc
 
     property :title,
@@ -50,6 +50,7 @@ module Api::V1
                },
                writeable: true,
                readable: true,
+               setter: AR_COLLECTION_SETTER,
                schema_info: {
                  required: true
                }

--- a/app/representers/api/v1/list_representer.rb
+++ b/app/representers/api/v1/list_representer.rb
@@ -15,35 +15,40 @@ module Api::V1
                class: ListNesting,
                extend: ListNestingRepresenter,
                writeable: true,
-               readable: true
+               readable: true,
+               setter: AR_COLLECTION_SETTER
 
     collection :list_publication_groups,
                as: :publication_groups,
                class: ListPublicationGroup,
                extend: ListPublicationGroupRepresenter,
                writeable: true,
-               readable: true
+               readable: true,
+               setter: AR_COLLECTION_SETTER
 
     collection :list_owners,
                as: :owners,
                class: ListOwner,
                extend: RoleRepresenter,
                writeable: true,
-               readable: true
+               readable: true,
+               setter: AR_COLLECTION_SETTER
 
     collection :list_editors,
                as: :editors,
                class: ListEditor,
                extend: RoleRepresenter,
                writeable: true,
-               readable: true
+               readable: true,
+               setter: AR_COLLECTION_SETTER
 
     collection :list_readers,
                as: :readers,
                class: ListReader,
                extend: RoleRepresenter,
                writeable: true,
-               readable: true
+               readable: true,
+               setter: AR_COLLECTION_SETTER
 
   end
 end

--- a/app/representers/api/v1/logic_representer.rb
+++ b/app/representers/api/v1/logic_representer.rb
@@ -3,7 +3,7 @@ module Api::V1
 
     include Roar::JSON
 
-    property :id, 
+    property :id,
              type: Integer,
              readable: true,
              writeable: false,
@@ -11,7 +11,7 @@ module Api::V1
                required: true
              }
 
-    property :language, 
+    property :language,
              type: String,
              writeable: true,
              readable: true,
@@ -32,7 +32,7 @@ module Api::V1
                extend: LogicVariableRepresenter,
                readable: true,
                writeable: true,
-               parse_strategy: :sync,
+               setter: AR_COLLECTION_SETTER,
                schema_info: {
                  required: true,
                  description: "The variables used in this Logic"

--- a/app/representers/api/v1/logic_variable_representer.rb
+++ b/app/representers/api/v1/logic_variable_representer.rb
@@ -7,8 +7,9 @@ module Api::V1
                as: :values,
                class: LogicVariableValue,
                extend: LogicVariableValueRepresenter,
-               readable: false,
-               writeable: true
+               readable: true,
+               writeable: true,
+               setter: AR_COLLECTION_SETTER
 
   end
 end

--- a/app/representers/api/v1/question_dependency_representer.rb
+++ b/app/representers/api/v1/question_dependency_representer.rb
@@ -9,11 +9,10 @@ module Api::V1
              readable: true,
              setter: ->(input:, **) do
                self.parent_question = dependent_question.exercise.questions
-                                        .find{ |ans| (ans.id || ans.temp_id) == input }
+                                        .find { |qq| (qq.id || qq.temp_id) == input }
              end
 
     property :is_optional,
-             as: :optional,
              writeable: true,
              readable: true,
              schema_info: {

--- a/app/representers/api/v1/stem_answer_representer.rb
+++ b/app/representers/api/v1/stem_answer_representer.rb
@@ -4,10 +4,11 @@ module Api::V1
     include Roar::JSON
 
     can_view_solutions_proc = ->(user_options:, **) do
-      user_options[:can_view_solutions] ||=
-        user_options.has_key?(:can_view_solutions) ?
-          user_options[:can_view_solutions] :
-          stem.question.exercise.can_view_solutions?(user_options[:user])
+      user_options[:can_view_solutions] = \
+        stem.question.exercise.can_view_solutions?(user_options[:user]) \
+        if user_options[:can_view_solutions].nil?
+
+      user_options[:can_view_solutions]
     end
 
     property :answer_id,
@@ -15,7 +16,7 @@ module Api::V1
              writeable: true,
              readable: true,
              setter: ->(input:, **) do
-               self.answer = question.answers.find{ |ans| (ans.id || ans.temp_id) == input }
+               self.answer = question.answers.find { |ans| (ans.id || ans.temp_id) == input }
              end,
              schema_info: {
                required: true

--- a/app/representers/api/v1/stem_representer.rb
+++ b/app/representers/api/v1/stem_representer.rb
@@ -18,13 +18,15 @@ module Api::V1
                class: StemAnswer,
                extend: StemAnswerRepresenter,
                writeable: true,
-               readable: true
+               readable: true,
+               setter: AR_COLLECTION_SETTER
 
     collection :combo_choices,
                class: ComboChoice,
                extend: ComboChoiceRepresenter,
                writeable: true,
-               readable: true
+               readable: true,
+               setter: AR_COLLECTION_SETTER
 
   end
 end

--- a/app/representers/api/v1/vocab_term_with_distractors_and_exercise_ids_representer.rb
+++ b/app/representers/api/v1/vocab_term_with_distractors_and_exercise_ids_representer.rb
@@ -15,6 +15,7 @@ module Api::V1
                extend: VocabDistractorRepresenter,
                writeable: true,
                readable: true,
+               setter: AR_COLLECTION_SETTER,
                schema_info: {
                  required: true
                }
@@ -23,6 +24,7 @@ module Api::V1
                type: String,
                writeable: true,
                readable: true,
+               setter: AR_COLLECTION_SETTER,
                schema_info: {
                  required: true
                }

--- a/app/routines/attach_file.rb
+++ b/app/routines/attach_file.rb
@@ -20,7 +20,7 @@ class AttachFile
     end
 
     attachment = Attachment.new(parent: attachable, asset: file)
-    existing_attachment = attachable.attachments.find{ |att| att.filename == attachment.filename }
+    existing_attachment = attachable.attachments.find { |att| att.filename == attachment.filename }
     if existing_attachment.nil?
       # The attachment MUST be saved or else the URL's returned will be wrong (tmp folder)
       attachment.save!

--- a/app/routines/exercises/import/old/row_importer.rb
+++ b/app/routines/exercises/import/old/row_importer.rb
@@ -8,7 +8,7 @@ module Exercises
       attr_reader :skip_first_row, :author, :copyright_holder
 
       def split(text, on: ',')
-        text.split(on).collect{|t| t.strip}
+        text.split(on).map {|t| t.strip}
       end
 
       # Parses the text using Markdown
@@ -56,7 +56,7 @@ module Exercises
         grouping_tags =  [book, [book, chapter].join('-'), [book, chapter, section].join('-')]
 
         los = split(row[3])
-        lo_tags = los.collect{|lo| [book, chapter, lo].join('-')}
+        lo_tags = los.map {|lo| [book, chapter, lo].join('-')}
         exercise_id_tag = row[4]
         type_tags = split(row[5])
         location_tag = row[6]

--- a/app/routines/exercises/import/old/row_importer.rb
+++ b/app/routines/exercises/import/old/row_importer.rb
@@ -72,7 +72,7 @@ module Exercises
         latest_exercise = Exercise
           .joins([{publication: :publication_group}, {exercise_tags: :tag}])
           .where(exercise_tags: {tag: {name: exercise_id_tag}})
-          .order{[publication.publication_group.number.desc, publication.version.desc]}.first
+          .order {[publication.publication_group.number.desc, publication.version.desc]}.first
 
         unless latest_exercise.nil?
           ex.publication.publication_group = latest_exercise.publication.publication_group

--- a/app/routines/exercises/import/old/xlsx.rb
+++ b/app/routines/exercises/import/old/xlsx.rb
@@ -29,10 +29,10 @@ module Exercises
         record_failures do
           book.each_row_streaming(offset: skip_first_row ? 1 : 0, pad_cells: true)
               .each_with_index do |row, index|
-            values = 0.upto(row.size-1).collect do |index|
+            values = 0.upto(row.size-1).map do |index|
               # Hack until Roo's new version with proper typecasting is released
-              val = row[index].try(:value)
-              Integer(val) rescue val
+              val = row[index].try!(:value)
+              Integer(val) rescue val.try!(:to_s)
             end
             next if values.compact.blank?
             import_row(values, index)

--- a/app/routines/exercises/import/quadbase.rb
+++ b/app/routines/exercises/import/quadbase.rb
@@ -254,8 +254,8 @@ module Exercises
           question = import_without_introduction(exercise, p['simple_question'])
           question.exercise = exercise
           id_map[p['simple_question']['id']] = question
-          prerequisites = (p['prerequisites'] || []).collect{|pre| pre['id']}
-          supports = (p['supported_by'] || []).collect{|pre| pre['id']}
+          prerequisites = (p['prerequisites'] || []).map {|pre| pre['id']}
+          supports = (p['supported_by'] || []).map {|pre| pre['id']}
           dependency_map[question] = {prerequisites: prerequisites, supports: supports}
           exercise.questions << question
         end
@@ -301,9 +301,9 @@ module Exercises
         tags = hash['tags'] || []
         filter_tag = "filter-type:import:qb"
 
-        module_tag = tags.find{ |tag| /\Am\d+\z/.match tag }
+        module_tag = tags.find { |tag| /\Am\d+\z/.match tag }
         if module_tag.nil?
-          book_location_tag = tags.find{ |tag| @book_location_regex.match tag }
+          book_location_tag = tags.find { |tag| @book_location_regex.match tag }
 
           if book_location_tag.nil?
             cnxmod_tag = nil
@@ -320,7 +320,7 @@ module Exercises
           cnxmod_tag = "context-cnxmod:#{uuid}"
         end
 
-        [filter_tag, cnxmod_tag].compact + tags.map{ |tag| "qb:#{tag}" }
+        [filter_tag, cnxmod_tag].compact + tags.map { |tag| "qb:#{tag}" }
       end
 
       # Creates a mapping from a CNX collection chapter and section numbers to their uuids

--- a/app/routines/exercises/import/quadbase.rb
+++ b/app/routines/exercises/import/quadbase.rb
@@ -39,7 +39,7 @@ module Exercises
         latest_exercise = Exercise
           .joins([{publication: :publication_group}, {exercise_tags: :tag}])
           .where(exercise_tags: {tag: {name: id_tag}})
-          .order{[publication.publication_group.number.desc, publication.version.desc]}.first
+          .order {[publication.publication_group.number.desc, publication.version.desc]}.first
 
         publication = import_metadata(exercise.publication, hash['attribution'])
 
@@ -96,7 +96,7 @@ module Exercises
         book_archive_url ||= original_book_archive_url
         book_archive_json_url = "#{book_archive_url.sub('.html', '')}.json"
         book_hash = HTTParty.get(book_archive_json_url).to_hash
-        @book_uuids = Hash.new{ |hash, key| hash[key] = {} }
+        @book_uuids = Hash.new { |hash, key| hash[key] = {} }
         map_collection_book_locations_to_uuids(book_hash['tree'], @book_uuids)
 
         original_book_archive_json_url = "#{original_book_archive_url}.json"

--- a/app/routines/search_exercises.rb
+++ b/app/routines/search_exercises.rb
@@ -22,6 +22,7 @@ class SearchExercises
     params[:ob] ||= [{number: :asc}, {version: :desc}]
     relation = Exercise.visible_for(options[:user]).joins(publication: :publication_group)
 
+    distinct = false
     # By default, only return the latest exercises visible to the user.
     # If either versions, uids or a publication date are specified,
     # this "latest" condition is disabled.
@@ -50,9 +51,9 @@ class SearchExercises
           else
             # Combine the id's one at a time using Squeel
             @items = @items.where do
-              only_numbers = sanitized_ids.select{ |sid| sid.second.blank? }.map(&:first)
-              only_versions = sanitized_ids.select{ |sid| sid.first.blank? }.map(&:second)
-              full_ids = sanitized_ids.reject{ |sid| sid.first.blank? || sid.second.blank? }
+              only_numbers = sanitized_ids.select { |sid| sid.second.blank? }.map(&:first)
+              only_versions = sanitized_ids.select { |sid| sid.first.blank? }.map(&:second)
+              full_ids = sanitized_ids.reject { |sid| sid.first.blank? || sid.second.blank? }
 
               cumulative_query = publication.uuid.in(only_numbers) |
                                  publication.publication_group.number.in(only_numbers) | \
@@ -130,6 +131,7 @@ class SearchExercises
           sanitized_tags = to_string_array(tag).map(&:downcase)
           next @items = @items.none if sanitized_tags.empty?
 
+          distinct = true
           @items = @items.joins(:tags).where(tags: {name: sanitized_tags})
         end
       end
@@ -140,7 +142,7 @@ class SearchExercises
                                                     prepend_wildcard: true)
           next @items = @items.none if sanitized_titles.empty?
 
-          @items = @items.where{title.like_any sanitized_titles}
+          @items = @items.where {title.like_any sanitized_titles}
         end
       end
 
@@ -150,8 +152,9 @@ class SearchExercises
                                                         prepend_wildcard: true)
           next @items = @items.none if sanitized_contents.empty?
 
-          @items = @items.joins{[questions.outer.stems.outer, questions.outer.answers.outer]}
-                         .where{
+          distinct = true
+          @items = @items.joins {[questions.outer.stems.outer, questions.outer.answers.outer]}
+                         .where {
                            (title.like_any sanitized_contents) |\
                            (stimulus.like_any sanitized_contents) |\
                            (questions.stimulus.like_any sanitized_contents) |\
@@ -167,8 +170,9 @@ class SearchExercises
                                                           prepend_wildcard: true)
           next @items = @items.none if sanitized_solutions.empty?
 
+          distinct = true
           @items = @items.joins(:solutions)
-                         .where{(solutions.summary.like_any sanitized_solutions) |\
+                         .where {(solutions.summary.like_any sanitized_solutions) |\
                                 (solutions.details.like_any sanitized_solutions)}
         end
       end
@@ -178,8 +182,9 @@ class SearchExercises
           sn = to_string_array(name, append_wildcard: true)
           next @items = @items.none if sn.empty?
 
+          distinct = true
           @items = @items.joins(publication: {authors: {user: :account}})
-                         .where{
+                         .where {
                            (publication.authors.user.account.username.like_any sn) |\
                            (publication.authors.user.account.first_name.like_any sn) |\
                            (publication.authors.user.account.last_name.like_any sn) |\
@@ -193,8 +198,9 @@ class SearchExercises
           sn = to_string_array(name, append_wildcard: true)
           next @items = @items.none if sn.empty?
 
+          distinct = true
           @items = @items.joins(publication: {copyright_holders: {user: :account}})
-                         .where{
+                         .where {
                            (publication.copyright_holders.user.account.username.like_any sn) |\
                            (publication.copyright_holders.user.account.first_name.like_any sn) |\
                            (publication.copyright_holders.user.account.last_name.like_any sn) |\
@@ -208,9 +214,10 @@ class SearchExercises
           sn = to_string_array(name, append_wildcard: true)
           next @items = @items.none if sn.empty?
 
-          @items = @items.joins{publication.authors.outer.user.outer.account.outer}
-                         .joins{publication.copyright_holders.outer.user.outer.account.outer}
-                         .where{
+          distinct = true
+          @items = @items.joins {publication.authors.outer.user.outer.account.outer}
+                         .joins {publication.copyright_holders.outer.user.outer.account.outer}
+                         .where {
                            (publication.authors.user.account.username.like_any sn) |\
                            (publication.authors.user.account.first_name.like_any sn) |\
                            (publication.authors.user.account.last_name.like_any sn) |\
@@ -229,13 +236,29 @@ class SearchExercises
         end.compact.min
         next @items = @items.none if min_published_before.nil?
 
-        @items = @items.where{ publication.published_at < min_published_before }
+        distinct = true
+        @items = @items.where { publication.published_at < min_published_before }
 
         # Latest now refers to results that happened before min_published_before
-        latest_scope = latest_scope.where{ publication.published_at < min_published_before } \
+        latest_scope = latest_scope.where { publication.published_at < min_published_before } \
           unless latest_scope.nil?
       end
 
+    end
+
+    if distinct
+      pg = PublicationGroup.arel_table
+      pb = Publication.arel_table
+
+      outputs[:items] = outputs[:items].select(
+        [
+          Exercise.arel_table[ Arel.star ],
+          pg[:uuid],
+          pg[:number],
+          pb[:version],
+          pb[:published_at]
+        ]
+      ).distinct
     end
 
     return if latest_scope.nil?

--- a/app/routines/search_exercises.rb
+++ b/app/routines/search_exercises.rb
@@ -34,7 +34,7 @@ class SearchExercises
       # Block to be used for searches by id or uid
       id_search_block = lambda do |ids|
         ids.each do |id|
-          sanitized_ids = to_string_array(id).map{|id| id.split('@')}
+          sanitized_ids = to_string_array(id).map { |id| id.split('@') }
           next @items = @items.none if sanitized_ids.empty?
 
           sanitized_numbers = sanitized_ids.map(&:first).compact
@@ -224,7 +224,7 @@ class SearchExercises
       end
 
       with.keyword :published_before do |published_befores|
-        min_published_before = published_befores.flatten.collect do |str|
+        min_published_before = published_befores.flatten.map do |str|
           DateTime.parse(str) rescue nil
         end.compact.min
         next @items = @items.none if min_published_before.nil?

--- a/app/routines/search_vocab_terms.rb
+++ b/app/routines/search_vocab_terms.rb
@@ -23,6 +23,7 @@ class SearchVocabTerms
     params[:ob] ||= [{number: :asc}, {version: :desc}]
     relation = VocabTerm.visible_for(options[:user]).joins(publication: :publication_group)
 
+    distinct = false
     # By default, only return the latest exercises visible to the user.
     # If either versions, uids or a publication date are specified,
     # this "latest" condition is disabled.
@@ -51,9 +52,9 @@ class SearchVocabTerms
           else
             # Combine the id's one at a time using Squeel
             @items = @items.where do
-              only_numbers = sanitized_ids.select{ |sid| sid.second.blank? }.map(&:first)
-              only_versions = sanitized_ids.select{ |sid| sid.first.blank? }.map(&:second)
-              full_ids = sanitized_ids.reject{ |sid| sid.first.blank? || sid.second.blank? }
+              only_numbers = sanitized_ids.select { |sid| sid.second.blank? }.map(&:first)
+              only_versions = sanitized_ids.select { |sid| sid.first.blank? }.map(&:second)
+              full_ids = sanitized_ids.reject { |sid| sid.first.blank? || sid.second.blank? }
 
               cumulative_query = publication.uuid.in(only_numbers) |
                                  publication.publication_group.number.in(only_numbers) | \
@@ -84,7 +85,7 @@ class SearchVocabTerms
           sanitized_names = to_string_array(name, append_wildcard: true, prepend_wildcard: true)
           next @items = @items.none if sanitized_names.empty?
 
-          @items = @items.where{name.like_any sanitized_names}
+          @items = @items.where {name.like_any sanitized_names}
         end
       end
 
@@ -132,6 +133,7 @@ class SearchVocabTerms
           sanitized_tags = to_string_array(tag).map(&:downcase)
           next @items = @items.none if sanitized_tags.empty?
 
+          distinct = true
           @items = @items.joins(:tags).where(tags: {name: sanitized_tags})
         end
       end
@@ -146,7 +148,7 @@ class SearchVocabTerms
                                                               prepend_wildcard: true)
           next @items = @items.none if sanitized_definitions.empty?
 
-          @items = @items.where{definition.like_any sanitized_definitions}
+          @items = @items.where {definition.like_any sanitized_definitions}
         end
       end
 
@@ -156,7 +158,7 @@ class SearchVocabTerms
                                                         prepend_wildcard: true)
           next @items = @items.none if sanitized_contents.empty?
 
-          @items = @items.where{ (name.like_any sanitized_contents) |\
+          @items = @items.where { (name.like_any sanitized_contents) |\
                                  (definition.like_any sanitized_contents) }
         end
       end
@@ -166,8 +168,9 @@ class SearchVocabTerms
           sn = to_string_array(name, append_wildcard: true)
           next @items = @items.none if sn.empty?
 
+          distinct = true
           @items = @items.joins(publication: {authors: {user: :account}})
-                         .where{
+                         .where {
                            (publication.authors.user.account.username.like_any sn) |\
                            (publication.authors.user.account.first_name.like_any sn) |\
                            (publication.authors.user.account.last_name.like_any sn) |\
@@ -181,8 +184,9 @@ class SearchVocabTerms
           sn = to_string_array(name, append_wildcard: true)
           next @items = @items.none if sn.empty?
 
+          distinct = true
           @items = @items.joins(publication: {copyright_holders: {user: :account}})
-                         .where{
+                         .where {
                            (publication.copyright_holders.user.account.username.like_any sn) |\
                            (publication.copyright_holders.user.account.first_name.like_any sn) |\
                            (publication.copyright_holders.user.account.last_name.like_any sn) |\
@@ -196,9 +200,10 @@ class SearchVocabTerms
           sn = to_string_array(name, append_wildcard: true)
           next @items = @items.none if sn.empty?
 
-          @items = @items.joins{publication.authors.outer.user.outer.account.outer}
-                         .joins{publication.copyright_holders.outer.user.outer.account.outer}
-                         .where{
+          distinct = true
+          @items = @items.joins {publication.authors.outer.user.outer.account.outer}
+                         .joins {publication.copyright_holders.outer.user.outer.account.outer}
+                         .where {
                            (publication.authors.user.account.username.like_any sn) |\
                            (publication.authors.user.account.first_name.like_any sn) |\
                            (publication.authors.user.account.last_name.like_any sn) |\
@@ -217,13 +222,28 @@ class SearchVocabTerms
         end.compact.min
         next @items = @items.none if min_published_before.nil?
 
-        @items = @items.where{ publication.published_at < min_published_before }
+        @items = @items.where { publication.published_at < min_published_before }
 
         # Latest now refers to results that happened before min_published_before
-        latest_scope = latest_scope.where{ publication.published_at < min_published_before } \
+        latest_scope = latest_scope.where { publication.published_at < min_published_before } \
           unless latest_scope.nil?
       end
 
+    end
+
+    if distinct
+      pg = PublicationGroup.arel_table
+      pb = Publication.arel_table
+
+      outputs[:items] = outputs[:items].select(
+        [
+          VocabTerm.arel_table[ Arel.star ],
+          pg[:uuid],
+          pg[:number],
+          pb[:version],
+          pb[:published_at]
+        ]
+      ).distinct
     end
 
     return if latest_scope.nil?

--- a/app/routines/search_vocab_terms.rb
+++ b/app/routines/search_vocab_terms.rb
@@ -35,7 +35,7 @@ class SearchVocabTerms
       # Block to be used for searches by id or uid
       id_search_block = lambda do |ids|
         ids.each do |id|
-          sanitized_ids = to_string_array(id).map{|id| id.split('@')}
+          sanitized_ids = to_string_array(id).map { |id| id.split('@') }
           next @items = @items.none if sanitized_ids.empty?
 
           sanitized_numbers = sanitized_ids.map(&:first).compact
@@ -212,7 +212,7 @@ class SearchVocabTerms
       end
 
       with.keyword :published_before do |published_befores|
-        min_published_before = published_befores.flatten.collect do |str|
+        min_published_before = published_befores.flatten.map do |str|
           DateTime.parse(str) rescue nil
         end.compact.min
         next @items = @items.none if min_published_before.nil?

--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -32,7 +32,9 @@ class AssetUploader < CarrierWave::Uploader::Base
   end
 
   def is_image?(ff = file)
-    mime_type(ff).try(:start_with?, 'image/')
+    mt = mime_type(ff)
+
+    !mt.nil? && mt.start_with?('image/')
   end
 
   def check_whitelist_pattern!(file)
@@ -41,7 +43,7 @@ class AssetUploader < CarrierWave::Uploader::Base
     raise(CarrierWave::IntegrityError, "Unknown asset type") if mime.nil?
 
     raise(CarrierWave::IntegrityError, "#{mime} is an invalid asset type") \
-      unless ALLOWED_EXTENSIONS.find{ |ext| mime.include?(ext) }
+      unless ALLOWED_EXTENSIONS.find { |ext| mime.include?(ext) }
   end
 
   def mime_type(file)
@@ -54,7 +56,7 @@ class AssetUploader < CarrierWave::Uploader::Base
       open(file)
     end
 
-    MimeMagic.by_magic(mm_file).try(:type)
+    MimeMagic.by_magic(mm_file).try!(:type)
   end
 
   def content_hash

--- a/app/views/admin/administrators/index.html.erb
+++ b/app/views/admin/administrators/index.html.erb
@@ -1,6 +1,6 @@
 <h4>Administrators</h4>
   <%= render partial: 'shared/users/index',
-             locals: {users: @administrators.collect{|a| a.user},
+             locals: {users: @administrators.map {|a| a.user},
                       action_partial: 'admin/administrators/destroy',
                       sign_in_as: true} %>
 

--- a/app/views/admin/trusted_applications/index.html.erb
+++ b/app/views/admin/trusted_applications/index.html.erb
@@ -1,6 +1,6 @@
 <h4>Trusted Applications</h4>
 <%= render partial: 'shared/applications/index',
-           locals: {applications: @trusted_applications.collect{|ta| ta.application},
+           locals: {applications: @trusted_applications.map {|ta| ta.application},
                     action_partial: 'admin/trusted_applications/destroy'} %>
 
 <br><br>

--- a/app/views/shared/users/_search_results.html.erb
+++ b/app/views/shared/users/_search_results.html.erb
@@ -6,7 +6,7 @@
 
 <% accounts = @handler_result.outputs[:items]
    return '' unless accounts
-   users = accounts.collect { |a| User.find_or_create_by(account: a) } %>
+   users = accounts.map { |a| User.find_or_create_by(account: a) } %>
 
 <%= render partial: 'shared/users/search_pagination' %>
 

--- a/config/environment.rb
+++ b/config/environment.rb
@@ -22,6 +22,8 @@ require 'solution'
 require 'stylable'
 require 'user_html'
 
+require 'ar_collection_setter'
+
 require 'active_record/calculations_patch'
 
 SITE_NAME = "OpenStax Exercises"

--- a/config/initializers/models.rb
+++ b/config/initializers/models.rb
@@ -10,7 +10,7 @@ ActiveRecord::Base.class_exec do
     attrs = attrs.except(*except) unless except.blank?
 
     if exclude_foreign_keys
-      foreign_keys = self.class.reflect_on_all_associations(:belongs_to).collect do |ar|
+      foreign_keys = self.class.reflect_on_all_associations(:belongs_to).map do |ar|
         ar.foreign_key
       end
       attrs = attrs.except(*foreign_keys)
@@ -24,7 +24,7 @@ ActiveRecord::Base.class_exec do
         next if objects.nil?
 
         if objects.respond_to?(:collect)
-          hash[name.to_s] = objects.collect do |object|
+          hash[name.to_s] = objects.map do |object|
             object.association_attributes(
               subtree,
               slice: slice,

--- a/db/migrate/20160610191504_remove_uuid_from_cnxfeature_tags.rb
+++ b/db/migrate/20160610191504_remove_uuid_from_cnxfeature_tags.rb
@@ -1,6 +1,6 @@
 class RemoveUuidFromCnxfeatureTags < ActiveRecord::Migration
   def up
-    Tag.where{name.like 'context-cnxfeature:%#%'}.update_all("name = regexp_replace(name, '^context-cnxfeature:[\\w-]+#([\\w-]+)$', 'context-cnxfeature:\\1')")
+    Tag.where {name.like 'context-cnxfeature:%#%'}.update_all("name = regexp_replace(name, '^context-cnxfeature:[\\w-]+#([\\w-]+)$', 'context-cnxfeature:\\1')")
   end
 
   def down

--- a/db/migrate/20161020001239_move_list_exercises_and_list_vocab_terms_to_list_publication_groups.rb
+++ b/db/migrate/20161020001239_move_list_exercises_and_list_vocab_terms_to_list_publication_groups.rb
@@ -6,12 +6,12 @@ class MoveListExercisesAndListVocabTermsToListPublicationGroups < ActiveRecord::
     vocab_term_id_list_id_pairs = \
       ActiveRecord::Base.connection.execute('SELECT list_id, vocab_term_id FROM list_vocab_terms;')
 
-    all_list_ids = exercise_id_list_id_pairs.map{ |hash| hash['list_id'] } +
-                   vocab_term_id_list_id_pairs.map{ |hash| hash['list_id'] }
+    all_list_ids = exercise_id_list_id_pairs.map { |hash| hash['list_id'] } +
+                   vocab_term_id_list_id_pairs.map { |hash| hash['list_id'] }
 
     list_by_list_id = List.where(id: all_list_ids).index_by(&:id)
 
-    all_exercise_ids = exercise_id_list_id_pairs.map{ |hash| hash['exercise_id'] }
+    all_exercise_ids = exercise_id_list_id_pairs.map { |hash| hash['exercise_id'] }
 
     publication_group_by_exercise_id = {}
     PublicationGroup.joins(:publications)
@@ -29,7 +29,7 @@ class MoveListExercisesAndListVocabTermsToListPublicationGroups < ActiveRecord::
       ListPublicationGroup.create(list: list, publication_group: pg)
     end
 
-    all_vocab_term_ids = vocab_term_id_list_id_pairs.map{ |hash| hash['vocab_term_id'] }
+    all_vocab_term_ids = vocab_term_id_list_id_pairs.map { |hash| hash['vocab_term_id'] }
 
     publication_group_by_vocab_term_id = {}
     PublicationGroup.joins(:publications)

--- a/lib/ar_collection_setter.rb
+++ b/lib/ar_collection_setter.rb
@@ -1,0 +1,15 @@
+AR_COLLECTION_SETTER = ->(input:, binding:, **) do
+   getter = binding[:getter]
+   collection = getter.nil? ? send(binding.getter) : getter.evaluate(self)
+
+  # Hard-delete records that are being replaced
+  # Any further dependent records must be handled with foreign key constraints
+  if collection.respond_to?(:loaded?) && !collection.loaded?
+    collection.delete_all :delete_all
+  else
+    collection.group_by(&:class).each { |klass, items| klass.where(id: items.map(&:id)).delete_all }
+  end
+
+  # Don't use the collection= method (setter) so we can return meaningful errors
+  input.each { |record| collection << record }
+end

--- a/lib/exercises/importer.rb
+++ b/lib/exercises/importer.rb
@@ -32,18 +32,18 @@ module Exercises
       ex = Exercise.new
 
       books = split(row[0])
-      book_tags = books.map{ |book| "book:#{book}" }
+      book_tags = books.map { |book| "book:#{book}" }
 
       chapter = row[1]
       section = row[2]
 
-      lo_tags = split(row[3]).map{ |lo| "lo:#{books.first}:#{chapter}-#{section}-#{lo}" }
+      lo_tags = split(row[3]).map { |lo| "lo:#{books.first}:#{chapter}-#{section}-#{lo}" }
 
       id_tag = "exid:#{books.first}:#{row[4]}"
 
       cnxmod_tag = "context-cnxmod:#{row[5]}"
 
-      type_tags = split(row[6]).map{ |type| "type:#{type}" }
+      type_tags = split(row[6]).map { |type| "type:#{type}" }
       dok_tag = "dok:#{row[7]}"
       blooms_tag = "blooms:#{row[8]}"
       time_tag = "time:#{row[10]}"

--- a/lib/exercises/importer.rb
+++ b/lib/exercises/importer.rb
@@ -54,7 +54,7 @@ module Exercises
       latest_exercise = Exercise
         .joins([{publication: :publication_group}, {exercise_tags: :tag}])
         .where(exercise_tags: {tag: {name: id_tag}})
-        .order{[publication.publication_group.number.desc, publication.version.desc]}.first
+        .order {[publication.publication_group.number.desc, publication.version.desc]}.first
 
       unless latest_exercise.nil?
         ex.publication.publication_group = latest_exercise.publication.publication_group

--- a/lib/has_tags.rb
+++ b/lib/has_tags.rb
@@ -28,6 +28,7 @@ module HasTags
         collection :tags,
                    writeable: true,
                    readable: true,
+                   setter: AR_COLLECTION_SETTER,
                    schema_info: {
                      items: {
                        type: "string"

--- a/lib/publishable/active_record.rb
+++ b/lib/publishable/active_record.rb
@@ -14,7 +14,7 @@ module Publishable
 
           delegate :uuid, :group_uuid, :number, :version, :uid, :published_at, :license,
                    :authors, :copyright_holders, :derivations,
-                   :is_yanked?, :is_published?, :is_embargoed?, :is_public?,
+                   :is_yanked?, :is_published?, :is_embargoed?, :is_public?, :is_latest?,
                    :has_collaborator?, :has_read_permission?, :has_write_permission?,
                    :license=, :authors=, :copyright_holders=, :derivations=,
                    to: :publication

--- a/lib/publishable/active_record.rb
+++ b/lib/publishable/active_record.rb
@@ -19,9 +19,9 @@ module Publishable
                    :license=, :authors=, :copyright_holders=, :derivations=,
                    to: :publication
 
-          scope :published, -> { joins(:publication).where{publication.published_at != nil} }
+          scope :published, -> { joins(:publication).where {publication.published_at != nil} }
 
-          scope :unpublished, -> { joins(:publication).where{publication.published_at == nil} }
+          scope :unpublished, -> { joins(:publication).where {publication.published_at == nil} }
 
           scope :with_id, ->(id) {
             nn, vv = id.to_s.split('@')
@@ -40,7 +40,7 @@ module Publishable
               else
                 wheres & (publication.version == vv)
               end
-            end.order{[publication.publication_group.number.asc, publication.version.desc]}
+            end.order {[publication.publication_group.number.asc, publication.version.desc]}
           }
 
           scope :visible_for, ->(user) {
@@ -104,7 +104,7 @@ module Publishable
                   scope
                     .reorder(nil).limit(nil).offset(nil)
                     .as(:newer_publishable)
-                    .on{ newer_publishable.id == ~publishable_id }
+                    .on { newer_publishable.id == ~publishable_id }
                 end
                 .as(:newer_publication)
                 .on do
@@ -112,7 +112,7 @@ module Publishable
                   (newer_publication.version > ~publication.version)
                 end
                 .outer
-            end.where{ newer_publication.id == nil }
+            end.where { newer_publication.id == nil }
           }
 
           after_initialize :build_publication, if: :new_record?, unless: :publication

--- a/lib/publishable/roar.rb
+++ b/lib/publishable/roar.rb
@@ -44,20 +44,23 @@ module Publishable
                    class: Author,
                    extend: Api::V1::RoleRepresenter,
                    writeable: true,
-                   readable: true
+                   readable: true,
+                   setter: AR_COLLECTION_SETTER
 
         collection :copyright_holders,
                    class: CopyrightHolder,
                    extend: Api::V1::RoleRepresenter,
                    writeable: true,
-                   readable: true
+                   readable: true,
+                   setter: AR_COLLECTION_SETTER
 
         collection :derivations,
                    as: :derived_from,
                    class: Publication,
                    extend: self,
                    writeable: true,
-                   readable: true
+                   readable: true,
+                   setter: AR_COLLECTION_SETTER
 
       end
     end

--- a/lib/row_parser.rb
+++ b/lib/row_parser.rb
@@ -13,7 +13,7 @@ module RowParser
 
       failures.empty? ? Rails.logger.info('Success!') :
                         Rails.logger.error("Failed rows: #{failures.keys}")
-      failures.each{ |key, value| Rails.logger.error "Row #{key}: #{value}" }
+      failures.each { |key, value| Rails.logger.error "Row #{key}: #{value}" }
     end
   end
 

--- a/lib/stylable.rb
+++ b/lib/stylable.rb
@@ -12,15 +12,17 @@ module Stylable
   module Roar
     module Decorator
       def stylable
-        collection :formats,
+        collection :stylings,
+                   as: :formats,
                    type: String,
-                   writeable: true,
                    readable: true,
-                   getter: ->(*) { stylings.map(&:style) },
-                   setter: ->(input:, **) do
-                     styling = stylings.find_or_initialize_by(style: input)
-                     stylings << styling unless styling.persisted?
+                   serialize: ->(input:, **) { input.style },
+                   writeable: true,
+                   class: Styling,
+                   deserialize: ->(input:, fragment:, **) do
+                     input.tap { |input| input.style = fragment }
                    end,
+                   setter: AR_COLLECTION_SETTER,
                    schema_info: {
                      required: true,
                      description: 'The question formats allowed for this object'

--- a/lib/tasks/vocab_terms/unlink.rake
+++ b/lib/tasks/vocab_terms/unlink.rake
@@ -1,9 +1,14 @@
 namespace :vocab_terms do
   desc 'unlinks all vocab terms that are currently linked to other terms'
-  task :unlink, :environment do
-    VocabTerm.joins(:vocab_distractors).latest(scope: VocabTerm.all).uniq.find_each do |vocab_term|
-      vocab_term = vocab_term.new_version if vocab_term.is_published?
-      vocab_term.unlink.save!
+  task unlink: :environment do
+    VocabTerm.joins(:vocab_distractors).latest(scope: VocabTerm.all)
+             .uniq.find_in_batches do |vocab_terms|
+      VocabTerm.transaction do
+        vocab_terms.each do |vocab_term|
+          vocab_term = vocab_term.new_version if vocab_term.is_published?
+          vocab_term.unlink.save!
+        end
+      end
     end
   end
 end

--- a/lib/vocab_terms/importer.rb
+++ b/lib/vocab_terms/importer.rb
@@ -57,8 +57,8 @@ module VocabTerms
           hash[name] = VocabTerm
             .joins([{publication: :publication_group}, {vocab_term_tags: :tag}])
             .where(name: name)
-            .where{vocab_term_tags.tag.name.like lo_like}
-            .order{[publication.publication_group.number.desc, publication.version.desc]}.first
+            .where {vocab_term_tags.tag.name.like lo_like}
+            .order {[publication.publication_group.number.desc, publication.version.desc]}.first
         end
       end
 
@@ -79,8 +79,8 @@ module VocabTerms
       vt.tags = [book_tag, lo_tag, cnxmod_tag, dok_tag, blooms_tag, time_tag, type_tag]
 
       # http://stackoverflow.com/a/8922049
-      grouped_distractor_terms = distractor_terms.reject(&:blank?).group_by{ |elt| elt }
-      duplicate_distractor_terms = grouped_distractor_terms.select{ |k, v| v.size > 1}.map(&:first)
+      grouped_distractor_terms = distractor_terms.reject(&:blank?).group_by { |elt| elt }
+      duplicate_distractor_terms = grouped_distractor_terms.select { |k, v| v.size > 1}.map(&:first)
       uniq_distractor_terms = grouped_distractor_terms.keys
 
       duplicate_distractor_terms.each do |ddt|

--- a/lib/xlsx/importer.rb
+++ b/lib/xlsx/importer.rb
@@ -15,8 +15,8 @@ module Xlsx
             .each_with_index do |row, row_index|
           values = 0.upto(row.size - 1).map do |value_index|
             # Hack until Roo's new version with proper typecasting is released
-            val = row[value_index].try(:value)
-            Integer(val) rescue val.try(:to_s)
+            val = row[value_index].try!(:value)
+            Integer(val) rescue val.try!(:to_s)
           end
           next if values.compact.blank?
 

--- a/lib/xlsx/tagger.rb
+++ b/lib/xlsx/tagger.rb
@@ -17,7 +17,7 @@ module Xlsx
       record_failures do |failures|
         book.each_row_streaming(offset: row_offset, pad_cells: true)
             .each_with_index do |row, row_index|
-          values = 0.upto(row.size - 1).map{ |index| row[index].try(:value).try(:to_s) }.compact
+          values = 0.upto(row.size - 1).map { |index| row[index].try!(:value).try!(:to_s) }.compact
           next if values.size < 2
 
           exercise_numbers = values.first.split(',').map(&:to_i)

--- a/lib/xlsx/tagger.rb
+++ b/lib/xlsx/tagger.rb
@@ -32,7 +32,7 @@ module Xlsx
             "WARNING: Couldn't find any Exercises with numbers #{not_found_numbers.join(', ')}"
           end unless not_found_numbers.empty?
 
-          tags = values.slice(1..-1).flat_map{ |value| value.split(',') }
+          tags = values.slice(1..-1).flat_map { |value| value.split(',') }
 
           row_number = row_index + row_offset + 1
 

--- a/spec/controllers/api/v1/exercises_controller_spec.rb
+++ b/spec/controllers/api/v1/exercises_controller_spec.rb
@@ -30,9 +30,9 @@ module Api::V1
         10.times { FactoryBot.create(:exercise, :published) }
 
         tested_strings = ["%adipisci%", "%draft%"]
-        Exercise.joins{questions.outer.stems.outer}
-                .joins{questions.outer.answers.outer}
-                .where{(title.like_any tested_strings) |\
+        Exercise.joins {questions.outer.stems.outer}
+                .joins {questions.outer.answers.outer}
+                .where {(title.like_any tested_strings) |\
                        (stimulus.like_any tested_strings) |\
                        (questions.stimulus.like_any tested_strings) |\
                        (stems.content.like_any tested_strings) |\

--- a/spec/controllers/api/v1/exercises_controller_spec.rb
+++ b/spec/controllers/api/v1/exercises_controller_spec.rb
@@ -8,14 +8,14 @@ module Api::V1
     let(:admin)             { FactoryBot.create :user, :administrator, :agreed_to_terms }
 
     let(:user_token)        { FactoryBot.create :doorkeeper_access_token,
-                                                  application: application,
-                                                  resource_owner_id: user.id }
+                                                application: application,
+                                                resource_owner_id: user.id }
     let(:admin_token)       { FactoryBot.create :doorkeeper_access_token,
-                                                  application: application,
-                                                  resource_owner_id: admin.id }
+                                                application: application,
+                                                resource_owner_id: admin.id }
     let(:application_token) { FactoryBot.create :doorkeeper_access_token,
-                                                  application: application,
-                                                  resource_owner_id: nil }
+                                                application: application,
+                                                resource_owner_id: nil }
 
     before do
       @exercise = FactoryBot.build(:exercise)
@@ -39,48 +39,48 @@ module Api::V1
                        (answers.content.like_any tested_strings)}.delete_all
 
         @exercise_1 = FactoryBot.build(:exercise, :published)
-        Api::V1::ExerciseRepresenter.new(@exercise_1).from_json({
-          tags: ['tag1', 'tag2'],
-          title: "Lorem ipsum",
-          stimulus: "Dolor",
-          questions: [{
-            stimulus: "Sit amet",
-            stem_html: "Consectetur adipiscing elit",
-            answers: [{
-              content_html: "Sed do eiusmod tempor"
+        Api::V1::ExerciseRepresenter.new(@exercise_1).from_hash(
+          'tags' => ['tag1', 'tag2'],
+          'title' => "Lorem ipsum",
+          'stimulus' => "Dolor",
+          'questions' => [{
+            'stimulus' => "Sit amet",
+            'stem_html' => "Consectetur adipiscing elit",
+            'answers' => [{
+              'content_html' => "Sed do eiusmod tempor"
             }]
           }]
-        }.to_json)
+        )
         @exercise_1.save!
 
         @exercise_2 = FactoryBot.build(:exercise, :published)
-        Api::V1::ExerciseRepresenter.new(@exercise_2).from_json({
-          tags: ['tag2', 'tag3'],
-          title: "Dolorem ipsum",
-          stimulus: "Quia dolor",
-          questions: [{
-            stimulus: "Sit amet",
-            stem_html: "Consectetur adipisci velit",
-            answers: [{
-              content_html: "Sed quia non numquam"
+        Api::V1::ExerciseRepresenter.new(@exercise_2).from_hash(
+          'tags' => ['tag2', 'tag3'],
+          'title' => "Dolorem ipsum",
+          'stimulus' => "Quia dolor",
+          'questions' => [{
+            'stimulus' => "Sit amet",
+            'stem_html' => "Consectetur adipisci velit",
+            'answers' => [{
+              'content_html' => "Sed quia non numquam"
             }]
           }]
-        }.to_json)
+        )
         @exercise_2.save!
 
         @exercise_draft = FactoryBot.build(:exercise)
-        Api::V1::ExerciseRepresenter.new(@exercise_draft).from_json({
-          tags: ['all', 'the', 'tags'],
-          title: "DRAFT",
-          stimulus: "This is a draft",
-          questions: [{
-            stimulus: "with no collaborators",
-            stem_html: "and should not appear",
-            answers: [{
-              content_html: "in most searches"
+        Api::V1::ExerciseRepresenter.new(@exercise_draft).from_hash(
+          'tags' => ['all', 'the', 'tags'],
+          'title' => "DRAFT",
+          'stimulus' => "This is a draft",
+          'questions' => [{
+            'stimulus' => "with no collaborators",
+            'stem_html' => "and should not appear",
+            'answers' => [{
+              'content_html' => "in most searches"
             }]
           }]
-        }.to_json)
+        )
         @exercise_draft.save!
       end
 

--- a/spec/controllers/api/v1/publications_controller_spec.rb
+++ b/spec/controllers/api/v1/publications_controller_spec.rb
@@ -42,7 +42,7 @@ module Api::V1
                                 .new(exercise.reload)
                                 .to_json(user_options: { user: exercise_author.user })
           expect(response).to have_http_status(:success)
-          expect(JSON.parse(response.body)).to eq JSON.parse(expected_response)
+          expect(response.body).to eq expected_response
           expect(exercise.is_published?).to eq true
         end
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -28,7 +28,7 @@ module Api::V1
       before do
         100.times { FactoryBot.create(:user) }
 
-        User.joins(:account).where{(account.first_name.like '%doe%') |
+        User.joins(:account).where {(account.first_name.like '%doe%') |
                                    (account.last_name.like '%doe%') |
                                    (account.username.like '%doe%')}.delete_all
 

--- a/spec/controllers/api/v1/vocab_terms_controller_spec.rb
+++ b/spec/controllers/api/v1/vocab_terms_controller_spec.rb
@@ -33,7 +33,7 @@ module Api::V1
         end
 
         tested_strings = ["%lorem ipsu%", "%adipiscing elit%", "draft"]
-        VocabTerm.where{(name.like_any tested_strings) |
+        VocabTerm.where {(name.like_any tested_strings) |
                         (definition.like_any tested_strings)}.delete_all
 
         @vocab_term_1 = FactoryBot.build(:vocab_term, :published)

--- a/spec/controllers/api/v1/vocab_terms_controller_spec.rb
+++ b/spec/controllers/api/v1/vocab_terms_controller_spec.rb
@@ -37,31 +37,30 @@ module Api::V1
                         (definition.like_any tested_strings)}.delete_all
 
         @vocab_term_1 = FactoryBot.build(:vocab_term, :published)
-        Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_1).from_json({
-          tags: ['tag1', 'tag2'],
-          term: "Lorem ipsum",
-          definition: "Dolor sit amet",
-          distractor_literals: ["Consectetur adipiscing elit", "Sed do eiusmod tempor"]
-        }.to_json)
+        Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_1).from_hash(
+          'tags' => ['tag1', 'tag2'],
+          'term' => "Lorem ipsum",
+          'definition' => "Dolor sit amet",
+          'distractor_literals' => ["Consectetur adipiscing elit", "Sed do eiusmod tempor"]
+        )
         @vocab_term_1.save!
 
         @vocab_term_2 = FactoryBot.build(:vocab_term, :published)
-        Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_2).from_json({
-          tags: ['tag2', 'tag3'],
-          term: "Dolorem ipsum",
-          definition: "Quia dolor sit amet",
-          distractor_literals: ["Consectetur adipisci velit", "Sed quia non numquam"]
-        }.to_json)
+        Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_2).from_hash(
+          'tags' => ['tag2', 'tag3'],
+          'term' => "Dolorem ipsum",
+          'definition' => "Quia dolor sit amet",
+          'distractor_literals' => ["Consectetur adipisci velit", "Sed quia non numquam"]
+        )
         @vocab_term_2.save!
 
         @vocab_term_draft = FactoryBot.build(:vocab_term)
-        Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_draft)
-                                                                  .from_json({
-          tags: ['all', 'the', 'tags'],
-          term: "draft",
-          definition: "Not ready for prime time",
-          distractor_literals: ["Release to production NOW"]
-        }.to_json)
+        Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_draft).from_hash(
+          'tags' => ['all', 'the', 'tags'],
+          'term' => "draft",
+          'definition' => "Not ready for prime time",
+          'distractor_literals' => ["Release to production NOW"]
+        )
         @vocab_term_draft.save!
       end
 
@@ -247,7 +246,7 @@ module Api::V1
           api_post :create, user_token,
                    raw_post_data: Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(
                      @vocab_term
-                   ).to_json(user: user)
+                   ).to_json(user_options: { user: user })
         }.to change(VocabTerm, :count).by(1)
         expect(response).to have_http_status(:success)
 

--- a/spec/factories/stem_answers.rb
+++ b/spec/factories/stem_answers.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :stem_answer do
     stem
     answer do
-      build(:answer, question: stem.question).tap{ |answer| stem.question.answers << answer }
+      build(:answer, question: stem.question).tap { |answer| stem.question.answers << answer }
     end
     feedback '<p>Some feedback</p>'
   end

--- a/spec/lib/tasks/vocab_terms/unlink_rake_spec.rb
+++ b/spec/lib/tasks/vocab_terms/unlink_rake_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe 'vocab_terms unlink', type: :rake do
                                                 distractor_literals: ['test']
   end
   let!(:draft_unlinked_vocab_term)     do
-    published_unlinked_vocab_term.new_version.tap{ |vocab_term| vocab_term.save! }
+    published_unlinked_vocab_term.new_version.tap { |vocab_term| vocab_term.save! }
   end
 
   context 'for linked vocab terms' do
@@ -25,7 +25,7 @@ RSpec.describe 'vocab_terms unlink', type: :rake do
 
     context 'where the latest version is a draft' do
       let!(:draft_linked_vocab_term)       do
-        published_linked_vocab_term.new_version.tap{ |vocab_term| vocab_term.save! }
+        published_linked_vocab_term.new_version.tap { |vocab_term| vocab_term.save! }
       end
 
       it 'calls #unlink on the latest version draft of the linked vocab_term' do

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -16,13 +16,13 @@ RSpec.describe Tag, type: :model do
                           '“smartquotes”', '‘smartquotes’'] }
 
   it 'validates the format of the tag\'s name' do
-    allowed_tags.each{ |tag_name| expect(Tag.new(name: tag_name)).to be_valid }
-    forbidden_tags.each{ |tag_name| expect(Tag.new(name: tag_name)).not_to be_valid }
+    allowed_tags.each { |tag_name| expect(Tag.new(name: tag_name)).to be_valid }
+    forbidden_tags.each { |tag_name| expect(Tag.new(name: tag_name)).not_to be_valid }
   end
 
   it 'converts tags passed to Tag.get() to the proper format' do
     tag_names_set = Set.new(Tag.get(allowed_tags + forbidden_tags).map(&:name))
-    allowed_tags.each{ |tag_name| expect(tag_names_set).to include(tag_name) }
+    allowed_tags.each { |tag_name| expect(tag_names_set).to include(tag_name) }
     forbidden_tags.compact.each do |tag_name|
       sanitized_name = tag_name.gsub(/[^\w:#]+/, '-').gsub(/(?:\A-|-\z)/, '')
       expect(tag_names_set).to include(sanitized_name) unless sanitized_name.blank?

--- a/spec/models/vocab_term_spec.rb
+++ b/spec/models/vocab_term_spec.rb
@@ -65,9 +65,9 @@ RSpec.describe VocabTerm, type: :model do
 
   it 'automatically publishes vocab exercises when published' do
     expect(vocab_term.exercises).not_to be_empty
-    vocab_term.exercises.each{ |exercise| expect(exercise).not_to be_is_published }
+    vocab_term.exercises.each { |exercise| expect(exercise).not_to be_is_published }
     vocab_term.publication.publish.save!
-    vocab_term.exercises.each{ |exercise| expect(exercise).to be_is_published }
+    vocab_term.exercises.each { |exercise| expect(exercise).to be_is_published }
   end
 
   it 'does not create extra versions of exercises when creating a new version' do
@@ -75,7 +75,7 @@ RSpec.describe VocabTerm, type: :model do
     vocab_term.exercises << vocab_term.exercises.first.new_version
     expect(vocab_term.exercises.size).to eq 2
     vocab_term.publication.publish.save!
-    vocab_term.exercises.each{ |exercise| expect(exercise).to be_is_published }
+    vocab_term.exercises.each { |exercise| expect(exercise).to be_is_published }
     new_version = vocab_term.new_version
     expect(new_version.exercises.size).to eq 1
   end

--- a/spec/representers/api/v1/exercise_representer_spec.rb
+++ b/spec/representers/api/v1/exercise_representer_spec.rb
@@ -3,126 +3,94 @@ require 'rails_helper'
 module Api::V1
   RSpec.describe ExerciseRepresenter, type: :representer do
 
-    let(:exercise) {
-      dbl = instance_spy(Exercise)
-      allow(dbl).to receive(:as_json).and_return(dbl)
-      allow(dbl).to receive(:questions).and_return([])
-      allow(dbl).to receive(:attachments).and_return([])
-      allow(dbl).to receive(:tags).and_return([])
-      allow(dbl).to receive(:logic).and_return(nil)
-      allow(dbl).to receive(:license).and_return(nil)
-      allow(dbl).to receive(:authors).and_return([])
-      allow(dbl).to receive(:copyright_holders).and_return([])
-      allow(dbl).to receive(:derivations).and_return([])
-      dbl
-    }
+    let(:vocab_term) { FactoryBot.create :vocab_term }
+    let(:exercise)   do
+      vocab_term.exercises.first.tap do |exercise|
+        exercise.title = 'A title'
+        exercise.stimulus = 'Stimulus package'
+        exercise.save!
+      end
+    end
 
     # This is lazily-evaluated on purpose
-    let(:representation) { described_class.new(exercise).as_json }
+    let(:representation) do
+      described_class.new(exercise).to_hash(user_options: { can_view_solutions: true })
+    end
 
     context 'vocab_term_uid' do
       it 'can be read' do
-        vocab_term = instance_spy(VocabTerm)
-        allow(vocab_term).to receive(:as_json).and_return(vocab_term)
-        allow(vocab_term).to receive(:uid).and_return('42@1')
-        allow(exercise).to receive(:vocab_term).and_return(vocab_term)
-        expect(representation).to include('vocab_term_uid' => '42@1')
+        expect(representation).to include('vocab_term_uid' => vocab_term.uid)
       end
 
       it 'cannot be written (attempts are silently ignored)' do
-        described_class.new(exercise).from_json({'vocab_term_uid' => '42@1'}.to_json)
-        expect(exercise).not_to have_received(:vocab_term=)
-        expect(exercise).not_to have_received(:vocab_term_id=)
+        expect(exercise).not_to receive(:vocab_term=)
+        expect(exercise).not_to receive(:vocab_term_id=)
+        described_class.new(exercise).from_hash('vocab_term_uid' => '42@1')
       end
     end
 
     context 'title' do
       it 'can be read' do
-        allow(exercise).to receive(:title).and_return('A cool exercise')
-        expect(representation).to include('title' => 'A cool exercise')
+        exercise.title = 'A title'
+        exercise.save!
+        expect(representation).to include('title' => exercise.title)
       end
 
       it 'can be written' do
-        described_class.new(exercise).from_json({'title' => 'A cooler exercise'}.to_json)
-        expect(exercise).to have_received(:title=).with('A cooler exercise')
+        expect(exercise).to receive(:title=).with('A cool exercise')
+        described_class.new(exercise).from_hash('title' => 'A cool exercise')
       end
     end
 
     context 'stimulus' do
       it 'can be read' do
-        allow(exercise).to receive(:stimulus).and_return('This exercise is cool.')
-        expect(representation).to include('stimulus_html' => 'This exercise is cool.')
+        expect(representation).to include('stimulus_html' => exercise.stimulus)
       end
 
       it 'can be written' do
-        described_class.new(exercise)
-                       .from_json({'stimulus_html' => 'This exercise is cooler.'}.to_json)
-        expect(exercise).to have_received(:stimulus=).with('This exercise is cooler.')
+        expect(exercise).to receive(:stimulus=).with('This exercise is cool.')
+        described_class.new(exercise).from_hash('stimulus_html' => 'This exercise is cool.')
       end
     end
 
     context 'questions' do
       it 'can be read' do
-        question_1 = instance_spy(Question)
-        allow(question_1).to receive(:id).and_return(1)
-        allow(question_1).to receive(:sort_position).and_return(2)
-        allow(question_1).to receive(:stimulus).and_return('Question 2')
-        question_2 = instance_spy(Question)
-        allow(question_2).to receive(:id).and_return(2)
-        allow(question_2).to receive(:sort_position).and_return(1)
-        allow(question_2).to receive(:stimulus).and_return('Question 1')
-        question_3 = instance_spy(Question)
-        allow(question_3).to receive(:id).and_return(3)
-        allow(question_3).to receive(:sort_position).and_return(3)
-        allow(question_3).to receive(:stimulus).and_return('Question 3')
+        3.times { exercise.questions << FactoryBot.build(:question, exercise: exercise) }
 
-        sorted_questions = [question_2, question_1, question_3]
-
-        question_representations = sorted_questions.map do |question|
-          allow(question).to receive(:as_json).and_return(question)
-          allow(question).to receive(:exercise).and_return(exercise)
-          allow(question).to receive(:stems).and_return([])
-          allow(question).to receive(:answers).and_return([])
-          allow(question).to receive(:collaborator_solutions).and_return([])
-          allow(question).to receive(:community_solutions).and_return([])
-          allow(question).to receive(:hints).and_return([])
-          allow(question).to receive(:parent_dependencies).and_return([])
-          SimpleQuestionRepresenter.new(question).to_hash
+        question_representations = exercise.questions.map do |question|
+          SimpleQuestionRepresenter.new(question).to_hash(
+            user_options: { can_view_solutions: true }
+          )
         end
-
-        allow(exercise).to receive(:questions).and_return(sorted_questions)
 
         expect(representation).to include('questions' => question_representations)
       end
 
       it 'can be written' do
-        # instance_spy doesn't work here because the Questions being created expect a real Exercise
-        real_ex = FactoryBot.build :exercise
+        expect(exercise.questions).to(
+          receive(:<<).with(kind_of(Question)).exactly(3).times do |question|
+            expect(question.stimulus).to be_in [ 'Question 1', 'Question 2', 'Question 3' ]
+          end
+        )
 
-        expect(real_ex).to receive(:questions=)
-                             .with(3.times.map{ a_kind_of(Question) }) do |questions|
-          expect(questions.first.stimulus).to  eq 'Question 1'
-          expect(questions.second.stimulus).to eq 'Question 2'
-          expect(questions.third.stimulus).to  eq 'Question 3'
-        end
-
-        described_class.new(real_ex).from_json({'questions' => [
-          { 'stimulus_html' => 'Question 1' },
-          { 'stimulus_html' => 'Question 2' },
-          { 'stimulus_html' => 'Question 3' }
-        ]}.to_json)
+        described_class.new(exercise).from_hash(
+          'questions' => [
+            { 'stimulus_html' => 'Question 1' },
+            { 'stimulus_html' => 'Question 2' },
+            { 'stimulus_html' => 'Question 3' }
+          ]
+        )
       end
     end
 
-    context "too many can_view_solutions? queries" do
+    context "can_view_solutions? queries" do
       let!(:real_exercise) { FactoryBot.create(:exercise, questions_count: 1)}
       let!(:user) { FactoryBot.create :user }
 
       it 'only calls can_view_solutions? one time' do
         expect_any_instance_of(Exercise).to receive(:can_view_solutions?).once.and_call_original
-        described_class.new(real_exercise).to_hash(user_options: {user: user})
+        described_class.new(real_exercise).as_json(user_options: {user: user})
       end
-
     end
 
   end

--- a/spec/representers/api/v1/question_representer_spec.rb
+++ b/spec/representers/api/v1/question_representer_spec.rb
@@ -3,147 +3,117 @@ require 'rails_helper'
 module Api::V1
   RSpec.describe QuestionRepresenter, type: :representer do
 
-    let(:exercise) {
-      dbl = instance_spy(Exercise)
-      allow(dbl).to receive(:as_json).and_return(dbl)
-      dbl
-    }
-
-    let(:question) {
-      dbl = instance_spy(Question)
-      allow(dbl).to receive(:as_json).and_return(dbl)
-      allow(dbl).to receive(:stems).and_return([])
-      allow(dbl).to receive(:answers).and_return([])
-      allow(dbl).to receive(:collaborator_solutions).and_return([])
-      allow(dbl).to receive(:community_solutions).and_return([])
-      allow(dbl).to receive(:hints).and_return([])
-      allow(dbl).to receive(:parent_dependencies).and_return([])
-      dbl
-    }
-
-    before do
-      allow(exercise).to receive(:questions).and_return([question])
-      allow(question).to receive(:exercise).and_return(exercise)
-    end
+    let(:exercise) { FactoryBot.create :exercise }
+    let(:question) { exercise.questions.first }
 
     # This is lazily-evaluated on purpose
-    let(:representation) {
-      described_class.new(question).as_json
-    }
+    let(:representation) do
+      described_class.new(question).to_hash(user_options: { can_view_solutions: true })
+    end
 
     context 'id' do
       it 'can be read' do
-        allow(question).to receive(:id).and_return(21)
-        expect(representation).to include('id' => 21)
+        expect(representation).to include('id' => question.id)
       end
 
       it 'can be written (sets the temp_id attribute)' do
-        described_class.new(question).from_json({'id' => 42}.to_json)
-        expect(question).to_not have_received(:id=)
-        expect(question).to have_received(:temp_id=).with(42)
+        expect(question).to_not receive(:id=)
+        expect(question).to receive(:temp_id=).with(42)
+        described_class.new(question).from_hash('id' => 42)
       end
     end
 
     context 'answer_order_matters' do
       it 'can be read' do
-        allow(question).to receive(:answer_order_matters).and_return(false)
-        expect(representation).to include('is_answer_order_important' => false)
+        expect(representation).to(
+          include('is_answer_order_important' => question.answer_order_matters)
+        )
       end
 
       it 'can be written' do
-        described_class.new(question).from_json({'is_answer_order_important' => false}.to_json)
-        expect(question).to have_received(:answer_order_matters=).with(false)
+        expect(question).to receive(:answer_order_matters=).with(false)
+        described_class.new(question).from_hash('is_answer_order_important' => false)
       end
     end
 
     context 'stimulus' do
       it 'can be read' do
-        allow(question).to receive(:stimulus).and_return('This question is cool.')
-        expect(representation).to include('stimulus_html' => 'This question is cool.')
+        expect(representation).to include('stimulus_html' => question.stimulus)
       end
 
       it 'can be written' do
-        described_class.new(question)
-                       .from_json({'stimulus_html' => 'This question is cooler.'}.to_json)
-        expect(question).to have_received(:stimulus=).with('This question is cooler.')
+        expect(question).to receive(:stimulus=).with('This question is cool.')
+        described_class.new(question).from_hash('stimulus_html' => 'This question is cool.')
       end
     end
 
     context 'stems' do
       it 'can be read' do
-        stems = [Stem.new(content: 'Don\'t you agree?')]
-        stem_representations = stems.collect{ |stem| StemRepresenter.new(stem).to_hash }
-        allow(question).to receive(:stems).and_return(stems)
+        stem_representations = question.stems.map do |stem|
+          StemRepresenter.new(stem).to_hash(user_options: { can_view_solutions: true })
+        end
         expect(representation).to include('stems' => stem_representations)
       end
 
       it 'can be written' do
-        stems = [Stem.new(content: 'Yes, I do!')]
-        stem_representations = stems.collect{ |stem| StemRepresenter.new(stem).to_hash }
-        described_class.new(question).from_json({ 'stems' => stem_representations }.to_json)
-        expect(question).to have_received(:stems=).with([ a_kind_of(Stem) ]) do |stems|
-          expect(stems.first.content).to eq 'Yes, I do!'
+        stems = [ Stem.new(content: "Don't you agree?") ]
+        stem_representations = stems.map do |stem|
+          StemRepresenter.new(stem).to_hash
         end
+        expect(question.stems).to receive(:<<).with(kind_of(Stem)) do |stem|
+          expect(stem.content).to eq "Don't you agree?"
+        end
+
+        described_class.new(question).from_hash(
+          'stems' => [ { 'content_html' => "Don't you agree?" } ]
+        )
       end
     end
 
     context 'answers' do
       it 'can be read' do
-        answer_1 = instance_spy(Answer)
-        allow(answer_1).to receive(:id).and_return(1)
-        allow(answer_1).to receive(:sort_position).and_return(2)
-        allow(answer_1).to receive(:content).and_return('No')
-        answer_2 = instance_spy(Answer)
-        allow(answer_2).to receive(:id).and_return(2)
-        allow(answer_2).to receive(:sort_position).and_return(1)
-        allow(answer_2).to receive(:content).and_return('Yes')
-        answer_3 = instance_spy(Answer)
-        allow(answer_3).to receive(:id).and_return(3)
-        allow(answer_3).to receive(:sort_position).and_return(3)
-        allow(answer_3).to receive(:content).and_return('Maybe so')
+        3.times { question.answers << FactoryBot.build(:answer, question: question) }
 
-        sorted_answers = [answer_2, answer_1, answer_3]
-
-        answer_representations = sorted_answers.map do |answer|
-          allow(answer).to receive(:as_json).and_return(answer)
-          allow(answer).to receive(:question).and_return(question)
-          allow(answer).to receive(:stem_answers).and_return([])
-          AnswerRepresenter.new(answer).to_hash
+        answer_representations = question.answers.map do |answer|
+          AnswerRepresenter.new(answer).as_json
         end
-
-        allow(question).to receive(:answers).and_return(sorted_answers)
 
         expect(representation).to include('answers' => answer_representations)
       end
 
       it 'can be written' do
-        # instance_spy doesn't work here because the Answers being created expect a real Question
-        real_q = FactoryBot.build :question
-
-        expect(real_q).to receive(:answers=).with(3.times.map{ a_kind_of(Answer) }) do |answers|
-          expect(answers.first.content).to eq 'Yes'
-          expect(answers.second.content).to eq 'No'
-          expect(answers.third.content).to eq 'Maybe so'
+        expect(question.answers).to receive(:<<).with(kind_of(Answer)).exactly(3).times do |answer|
+          expect(answer.content).to be_in [ 'Yes', 'No', 'Maybe so' ]
         end
 
-        described_class.new(real_q).from_json({'answers' => [
-          { 'content_html' => 'Yes' }, { 'content_html' => 'No' }, { 'content_html' => 'Maybe so' }
-        ]}.to_json)
+        described_class.new(question).from_hash(
+          'answers' => [
+            { 'content_html' => 'Yes' },
+            { 'content_html' => 'No' },
+            { 'content_html' => 'Maybe so' }
+          ]
+        )
       end
     end
 
     context 'collaborator_solutions' do
       it 'can be read' do
-        solutions = [CollaboratorSolution.new(content: 'Of course.')]
-        solution_representations = solutions.collect do |sol|
-          CollaboratorSolutionRepresenter.new(sol).to_hash
+        solution_representations = question.collaborator_solutions.map do |sol|
+          CollaboratorSolutionRepresenter.new(sol).as_json
         end
-        allow(question).to receive(:collaborator_solutions).and_return(solutions)
         expect(representation).to include('collaborator_solutions' => solution_representations)
       end
 
       it 'can be written' do
-        described_class.new(question).from_json(
+        expect(question.collaborator_solutions).to(
+          receive(:<<).with(kind_of(CollaboratorSolution)) do |collaborator_solution|
+            expect(collaborator_solution.title).to eq 'Test'
+            expect(collaborator_solution.solution_type).to eq 'example'
+            expect(collaborator_solution.content).to eq 'This is a test.'
+          end
+        )
+
+        described_class.new(question).from_hash(
           {
             'collaborator_solutions' => [
               {
@@ -152,30 +122,24 @@ module Api::V1
                 'content_html' => 'This is a test.'
               }
             ]
-          }.to_json
+          },
+          user_options: { can_view_solutions: true }
         )
-
-        expect(question).to have_received(:collaborator_solutions=)
-                              .with([a_kind_of(CollaboratorSolution)]) do |collaborator_solutions|
-          expect(collaborator_solutions.first.title).to eq 'Test'
-          expect(collaborator_solutions.first.solution_type).to eq 'example'
-          expect(collaborator_solutions.first.content).to eq 'This is a test.'
-        end
       end
     end
 
     context 'community_solutions' do
       it 'can be read' do
-        solutions = [CommunitySolution.new(content: 'Of course.')]
-        solution_representations = solutions.collect do |sol|
-          CommunitySolutionRepresenter.new(sol).to_hash
+        solution_representations = question.community_solutions.map do |sol|
+          CommunitySolutionRepresenter.new(sol).as_json
         end
-        allow(question).to receive(:community_solutions).and_return(solutions)
         expect(representation).to include('community_solutions' => solution_representations)
       end
 
       it 'cannot be written (attempts are silently ignored)' do
-        described_class.new(question).from_json(
+        expect(question.community_solutions).not_to receive(:<<)
+
+        described_class.new(question).from_hash(
           {
             'community_solutions' => [
               {
@@ -184,33 +148,44 @@ module Api::V1
                 'content_html' => 'This is a test.'
               }
             ]
-          }.to_json
+          },
+          user_options: { can_view_solutions: true }
         )
-
-        expect(question).not_to have_received(:community_solutions=)
       end
     end
 
     context 'hints' do
       it 'can be read' do
-        hints = [Hint.new(content: 'A hint.')]
-        hint_representations = hints.collect{ |hint| hint.content }
-        allow(question).to receive(:hints).and_return(hints)
+        hint_representations = question.hints.map(&:content)
         expect(representation).to include('hints' => hint_representations)
       end
 
-      xit 'can be written' do
+      it 'can be written' do
+        expect(question.hints).to receive(:<<).with(kind_of(Hint)) do |hint|
+          expect(hint.content).to eq 'A hint'
+        end
+
+        described_class.new(question).from_hash('hints' => [ 'A hint' ])
       end
     end
 
     context 'parent_dependencies' do
       it 'can be read' do
-        parent_dependencies = []
-        allow(question).to receive(:parent_dependencies).and_return(parent_dependencies)
-        expect(representation).to include('dependencies' => parent_dependencies)
+        expect(representation).to include('dependencies' => question.parent_dependencies)
       end
 
-      xit 'can be written' do
+      it 'can be written' do
+        expect(question.parent_dependencies).to(
+          receive(:<<).with(kind_of(QuestionDependency)) do |question_dependency|
+            expect(question_dependency.dependent_question).to eq question
+            expect(question_dependency.parent_question).to eq question
+            expect(question_dependency.is_optional).to eq true
+          end
+        )
+
+        described_class.new(question).from_hash(
+          'dependencies' => [ 'parent_question_id' => question.id, 'is_optional' => true ]
+        )
       end
     end
 

--- a/spec/representers/api/v1/simple_question_representer_spec.rb
+++ b/spec/representers/api/v1/simple_question_representer_spec.rb
@@ -3,154 +3,108 @@ require 'rails_helper'
 module Api::V1
   RSpec.describe SimpleQuestionRepresenter, type: :representer do
 
-    let(:exercise) {
-      dbl = instance_spy(Exercise)
-      allow(dbl).to receive(:as_json).and_return(dbl)
-      dbl
-    }
+    let(:exercise) { FactoryBot.create :exercise }
+    let(:question) { exercise.questions.first }
+    let(:stem)     { question.stems.first }
 
-    let(:question) {
-      dbl = instance_spy(Question)
-      allow(dbl).to receive(:as_json).and_return(dbl)
-      allow(dbl).to receive(:answers).and_return([])
-      allow(dbl).to receive(:collaborator_solutions).and_return([])
-      allow(dbl).to receive(:community_solutions).and_return([])
-      allow(dbl).to receive(:hints).and_return([])
-      allow(dbl).to receive(:parent_dependencies).and_return([])
-      dbl
-    }
-
-    let(:stem) {
-      dbl = instance_spy(Stem)
-      allow(dbl).to receive(:as_json).and_return(dbl)
-      allow(dbl).to receive(:stylings).and_return([])
-      allow(dbl).to receive(:stem_answers).and_return([])
-      allow(dbl).to receive(:combo_choices).and_return([])
-      dbl
-    }
-
-    before do
-      allow(exercise).to receive(:questions).and_return([question])
-      allow(question).to receive(:exercise).and_return(exercise)
-      allow(question).to receive(:stems).and_return([stem])
-      allow(stem).to receive(:question).and_return(question)
-    end
 
     # This is lazily-evaluated on purpose
-    let(:representation) {
-      described_class.new(question).as_json
-    }
+    let(:representation) do
+      described_class.new(question).to_hash(user_options: { can_view_solutions: true })
+    end
 
     context 'id' do
       it 'can be read' do
-        allow(question).to receive(:id).and_return(21)
-        expect(representation).to include('id' => 21)
+        expect(representation).to include('id' => question.id)
       end
 
       it 'cannot be written (attempts are silently ignored)' do
-        described_class.new(question).from_json({'id' => 42}.to_json)
-        expect(question).to_not have_received(:id=)
-        expect(question).to_not have_received(:temp_id=)
+        expect(question).to_not receive(:id=)
+        expect(question).to_not receive(:temp_id=)
+        described_class.new(question).from_hash('id' => 42)
       end
     end
 
     context 'stimulus' do
       it 'can be read' do
-        allow(question).to receive(:stimulus).and_return('This question is cool.')
-        expect(representation).to include('stimulus_html' => 'This question is cool.')
+        expect(representation).to include('stimulus_html' => question.stimulus)
       end
 
       it 'can be written' do
-        described_class.new(question)
-                       .from_json({'stimulus_html' => 'This question is cooler.'}.to_json)
-        expect(question).to have_received(:stimulus=).with('This question is cooler.')
+        expect(question).to receive(:stimulus=).with('This question is cool.')
+
+        described_class.new(question).from_hash('stimulus_html' => 'This question is cool.')
       end
     end
 
     context 'stem_html' do
       it 'can be read' do
-        stem = Stem.new(content: 'Don\'t you agree?')
-        stem_representation = stem.content
-        allow(question).to receive(:stems).and_return([stem])
-        expect(representation).to include('stem_html' => stem_representation)
+        expect(representation).to include('stem_html' => stem.content)
       end
 
       it 'can be written' do
-        described_class.new(question)
-                       .from_json({'stem_html' => 'Yes, I do!'}.to_json)
-        expect(question.stems.first).to have_received(:content=).with('Yes, I do!')
+        expect(stem).to receive(:content=).with("Don't you agree?")
+        described_class.new(question).from_hash('stem_html' => "Don't you agree?")
       end
     end
 
     context 'answer_order_matters' do
       it 'can be read' do
-        allow(question).to receive(:answer_order_matters).and_return(false)
-        expect(representation).to include('is_answer_order_important' => false)
+        expect(representation).to(
+          include('is_answer_order_important' => question.answer_order_matters)
+        )
       end
 
       it 'can be written' do
-        described_class.new(question).from_json({'is_answer_order_important' => false}.to_json)
-        expect(question).to have_received(:answer_order_matters=).with(false)
+        expect(question).to receive(:answer_order_matters=).with(false)
+        described_class.new(question).from_hash('is_answer_order_important' => false)
       end
     end
 
     context 'answers' do
       it 'can be read' do
-        answer_1 = instance_spy(Answer)
-        allow(answer_1).to receive(:id).and_return(1)
-        allow(answer_1).to receive(:sort_position).and_return(2)
-        allow(answer_1).to receive(:content).and_return('No')
-        answer_2 = instance_spy(Answer)
-        allow(answer_2).to receive(:id).and_return(2)
-        allow(answer_2).to receive(:sort_position).and_return(1)
-        allow(answer_2).to receive(:content).and_return('Yes')
-        answer_3 = instance_spy(Answer)
-        allow(answer_3).to receive(:id).and_return(3)
-        allow(answer_3).to receive(:sort_position).and_return(3)
-        allow(answer_3).to receive(:content).and_return('Maybe so')
+        3.times { question.answers << FactoryBot.build(:answer, question: question) }
 
-        sorted_answers = [answer_2, answer_1, answer_3]
-
-        answer_representations = sorted_answers.map do |answer|
-          allow(answer).to receive(:as_json).and_return(answer)
-          allow(answer).to receive(:question).and_return(question)
-          allow(answer).to receive(:stem_answers).and_return([])
-          AnswerRepresenter.new(answer).to_hash
+        answer_representations = question.answers.map do |answer|
+          SimpleAnswerRepresenter.new(answer).to_hash(user_options: { can_view_solutions: true })
         end
-
-        allow(question).to receive(:answers).and_return(sorted_answers)
 
         expect(representation).to include('answers' => answer_representations)
       end
 
       it 'can be written' do
-        # instance_spy doesn't work here because the Answers being created expect a real Question
-        real_q = FactoryBot.build :question
-
-        expect(real_q).to receive(:answers=).with(3.times.map{ a_kind_of(Answer) }) do |answers|
-          expect(answers.first.content).to eq 'Yes'
-          expect(answers.second.content).to eq 'No'
-          expect(answers.third.content).to eq 'Maybe so'
+        expect(question.answers).to receive(:<<).with(kind_of(Answer)).exactly(3).times do |answer|
+          expect(answer.content).to be_in [ 'Yes', 'No', 'Maybe so' ]
         end
 
-        described_class.new(real_q).from_json({'answers' => [
-          { 'content_html' => 'Yes' }, { 'content_html' => 'No' }, { 'content_html' => 'Maybe so' }
-        ]}.to_json)
+        described_class.new(question).from_hash(
+          'answers' => [
+            { 'content_html' => 'Yes' },
+            { 'content_html' => 'No' },
+            { 'content_html' => 'Maybe so' }
+          ]
+        )
       end
     end
 
     context 'collaborator_solutions' do
       it 'can be read' do
-        solutions = [CollaboratorSolution.new(content: 'Of course.')]
-        solution_representations = solutions.collect do |sol|
-          CollaboratorSolutionRepresenter.new(sol).to_hash
+        solution_representations = question.collaborator_solutions.map do |sol|
+          CollaboratorSolutionRepresenter.new(sol).as_json
         end
-        allow(question).to receive(:collaborator_solutions).and_return(solutions)
         expect(representation).to include('collaborator_solutions' => solution_representations)
       end
 
       it 'can be written' do
-        described_class.new(question).from_json(
+        expect(question.collaborator_solutions).to(
+          receive(:<<).with(kind_of(CollaboratorSolution)) do |collaborator_solution|
+            expect(collaborator_solution.title).to eq 'Test'
+            expect(collaborator_solution.solution_type).to eq 'example'
+            expect(collaborator_solution.content).to eq 'This is a test.'
+          end
+        )
+
+        described_class.new(question).from_hash(
           {
             'collaborator_solutions' => [
               {
@@ -159,30 +113,24 @@ module Api::V1
                 'content_html' => 'This is a test.'
               }
             ]
-          }.to_json
+          },
+          user_options: { can_view_solutions: true }
         )
-
-        expect(question).to have_received(:collaborator_solutions=)
-                              .with([a_kind_of(CollaboratorSolution)]) do |collaborator_solutions|
-          expect(collaborator_solutions.first.title).to eq 'Test'
-          expect(collaborator_solutions.first.solution_type).to eq 'example'
-          expect(collaborator_solutions.first.content).to eq 'This is a test.'
-        end
       end
     end
 
     context 'community_solutions' do
       it 'can be read' do
-        solutions = [CommunitySolution.new(content: 'Of course.')]
-        solution_representations = solutions.collect do |sol|
-          CommunitySolutionRepresenter.new(sol).to_hash
+        solution_representations = question.community_solutions.map do |sol|
+          CommunitySolutionRepresenter.new(sol).as_json
         end
-        allow(question).to receive(:community_solutions).and_return(solutions)
         expect(representation).to include('community_solutions' => solution_representations)
       end
 
       it 'cannot be written (attempts are silently ignored)' do
-        described_class.new(question).from_json(
+        expect(question.community_solutions).not_to receive(:<<)
+
+        described_class.new(question).from_hash(
           {
             'community_solutions' => [
               {
@@ -191,24 +139,60 @@ module Api::V1
                 'content_html' => 'This is a test.'
               }
             ]
-          }.to_json
+          },
+          user_options: { can_view_solutions: true }
         )
-
-        expect(question).not_to have_received(:community_solutions=)
       end
     end
 
     context 'hints' do
       it 'can be read' do
-        hints = [Hint.new(content: 'A hint.')]
-        hint_representations = hints.collect{ |hint| hint.content }
-        allow(question).to receive(:hints).and_return(hints)
+        hint_representations = question.hints.map(&:content)
         expect(representation).to include('hints' => hint_representations)
       end
 
-      xit 'can be written' do
+      it 'can be written' do
+        expect(question.hints).to receive(:<<).with(kind_of(Hint)) do |hint|
+          expect(hint.content).to eq 'A hint'
+        end
+
+        described_class.new(question).from_hash('hints' => [ 'A hint' ])
       end
     end
 
+    context 'formats' do
+      it 'can be read' do
+        styling_representations = stem.stylings.map(&:style)
+        expect(representation).to include('formats' => styling_representations)
+      end
+
+      it 'can be written' do
+        expect(stem.stylings).to receive(:<<).twice.with(kind_of(Styling)) do |styling|
+          expect(styling.style).to be_in [ 'multiple-choice', 'free-response' ]
+        end
+
+        described_class.new(question).from_hash('formats' => [ 'multiple-choice', 'free-response' ])
+      end
+    end
+
+    context 'combo_choices' do
+      it 'can be read' do
+        combo_choice_representations = stem.combo_choices.map do |combo_choice|
+          ComboChoiceRepresenter.new(combo_choice).as_json
+        end
+        expect(representation).to include('combo_choices' => combo_choice_representations)
+      end
+
+      it 'can be written' do
+        expect(stem.combo_choices).to receive(:<<).with(kind_of(ComboChoice)) do |combo_choice|
+          expect(combo_choice.combo_choice_answers).to eq []
+          expect(combo_choice.correctness).to eq 0.0
+        end
+
+        described_class.new(question).from_hash(
+          'combo_choices' => [ { 'combo_choice_answers' => [], 'correctness' => 0.0 } ]
+        )
+      end
+    end
   end
 end

--- a/spec/representers/api/v1/vocab_distractor_representer_spec.rb
+++ b/spec/representers/api/v1/vocab_distractor_representer_spec.rb
@@ -3,75 +3,54 @@ require 'rails_helper'
 module Api::V1
   RSpec.describe VocabDistractorRepresenter, type: :representer do
 
-    let(:distractor_term) {
-      instance_spy(VocabTerm).tap do |dbl|
-        allow(dbl).to receive(:as_json).and_return(dbl)
-      end
-    }
-
-    let(:vocab_distractor) {
-      instance_spy(VocabDistractor).tap do |dbl|
-        allow(dbl).to receive(:as_json).and_return(dbl)
-        allow(dbl).to receive(:tags).and_return([])
-        allow(dbl).to receive(:license).and_return(nil)
-        allow(dbl).to receive(:authors).and_return([])
-        allow(dbl).to receive(:copyright_holders).and_return([])
-        allow(dbl).to receive(:derivations).and_return([])
-        allow(dbl).to receive(:distractor_term).and_return(distractor_term)
-      end
-    }
+    let(:vocab_distractor) { FactoryBot.create :vocab_distractor }
+    let(:distractor_term)  { vocab_distractor.distractor_term }
 
     # This is lazily-evaluated on purpose
     let(:representation) { described_class.new(vocab_distractor).as_json }
 
     context 'group_uuid' do
       it 'can be read' do
-        uuid = SecureRandom.uuid
-        allow(vocab_distractor).to receive(:group_uuid).and_return(uuid)
-        expect(representation).to include('group_uuid' => uuid)
+        expect(representation).to include('group_uuid' => vocab_distractor.group_uuid)
       end
 
       it 'can be written' do
         uuid = SecureRandom.uuid
-        described_class.new(vocab_distractor).from_json({'group_uuid' => uuid}.to_json)
-        expect(vocab_distractor).to have_received(:group_uuid=).with(uuid)
+        expect(vocab_distractor).to receive(:group_uuid=).with(uuid)
+        described_class.new(vocab_distractor).from_hash('group_uuid' => uuid)
       end
     end
 
     context 'number' do
       it 'can be read' do
-        allow(vocab_distractor).to receive(:number).and_return(42)
-        expect(representation).to include('number' => 42)
+        expect(representation).to include('number' => vocab_distractor.number)
       end
 
       it 'cannot be written (attempts are silently ignored)' do
-        described_class.new(vocab_distractor).from_json({'number' => 84}.to_json)
-        expect(vocab_distractor).not_to have_received(:number=)
+        expect(vocab_distractor).not_to receive(:number=)
+        described_class.new(vocab_distractor).from_hash('number' => 42)
       end
     end
 
     context 'term' do
       it 'can be read' do
-        allow(vocab_distractor).to receive(:name).and_return('Question')
-        expect(representation).to include('term' => 'Question')
+        expect(representation).to include('term' => vocab_distractor.name)
       end
 
       it 'cannot be written (attempts are silently ignored)' do
-        described_class.new(vocab_distractor).from_json({'term' => 'Exercise'}.to_json)
-        expect(distractor_term).not_to have_received(:name=)
+        expect(distractor_term).not_to receive(:name=)
+        described_class.new(vocab_distractor).from_hash('term' => 'Exercise')
       end
     end
 
     context 'definition' do
       it 'can be read' do
-        allow(vocab_distractor).to receive(:definition).and_return('This term is cool.')
-        expect(representation).to include('definition' => 'This term is cool.')
+        expect(representation).to include('definition' => vocab_distractor.definition)
       end
 
       it 'cannot be written (attempts are silently ignored)' do
-        described_class.new(vocab_distractor)
-                       .from_json({'definition' => 'This term is cooler.'}.to_json)
-        expect(distractor_term).not_to have_received(:definition=)
+        expect(distractor_term).not_to receive(:definition=)
+        described_class.new(vocab_distractor).from_hash('definition' => 'This term is cool.')
       end
     end
 

--- a/spec/representers/api/v1/vocab_term_representer_spec.rb
+++ b/spec/representers/api/v1/vocab_term_representer_spec.rb
@@ -3,44 +3,30 @@ require 'rails_helper'
 module Api::V1
   RSpec.describe VocabTermRepresenter, type: :representer do
 
-    let(:vocab_term) {
-      dbl = instance_spy(VocabTerm)
-      allow(dbl).to receive(:as_json).and_return(dbl)
-      allow(dbl).to receive(:distractor_terms).and_return([])
-      allow(dbl).to receive(:distractor_literals).and_return([])
-      allow(dbl).to receive(:tags).and_return([])
-      allow(dbl).to receive(:license).and_return(nil)
-      allow(dbl).to receive(:authors).and_return([])
-      allow(dbl).to receive(:copyright_holders).and_return([])
-      allow(dbl).to receive(:derivations).and_return([])
-      dbl
-    }
+    let(:vocab_term) { FactoryBot.create :vocab_term }
 
     # This is lazily-evaluated on purpose
     let(:representation) { described_class.new(vocab_term).as_json }
 
     context 'term' do
       it 'can be read' do
-        allow(vocab_term).to receive(:name).and_return('Question')
-        expect(representation).to include('term' => 'Question')
+        expect(representation).to include('term' => vocab_term.name)
       end
 
       it 'can be written' do
-        described_class.new(vocab_term).from_json({'term' => 'Exercise'}.to_json)
-        expect(vocab_term).to have_received(:name=).with('Exercise')
+        expect(vocab_term).to receive(:name=).with('Exercise')
+        described_class.new(vocab_term).from_hash('term' => 'Exercise')
       end
     end
 
     context 'definition' do
       it 'can be read' do
-        allow(vocab_term).to receive(:definition).and_return('This term is cool.')
-        expect(representation).to include('definition' => 'This term is cool.')
+        expect(representation).to include('definition' => vocab_term.definition)
       end
 
       it 'can be written' do
-        described_class.new(vocab_term)
-                       .from_json({'definition' => 'This term is cooler.'}.to_json)
-        expect(vocab_term).to have_received(:definition=).with('This term is cooler.')
+        expect(vocab_term).to receive(:definition=).with('This term is cool.')
+        described_class.new(vocab_term).from_hash('definition' => 'This term is cool.')
       end
     end
 

--- a/spec/routines/exercises/import/old/xlsx_spec.rb
+++ b/spec/routines/exercises/import/old/xlsx_spec.rb
@@ -45,7 +45,7 @@ module Exercises::Import
         stem = question.stems.first
         expect(stem.content).not_to be_blank
         expect(stem.stem_answers).not_to be_blank
-        expect(Set.new(stem.stem_answers.collect{ |sa| sa.answer })).to eq Set.new(question.answers)
+        expect(Set.new(stem.stem_answers.map { |sa| sa.answer })).to eq Set.new(question.answers)
         expect(stem.stem_answers.any?{ |answer| answer.correctness == 1.0 }).to eq true
 
         stem.stem_answers.each do |stem_answer|

--- a/spec/routines/exercises/import/old/zip_spec.rb
+++ b/spec/routines/exercises/import/old/zip_spec.rb
@@ -35,7 +35,7 @@ module Exercises::Import
         stem = question.stems.first
         expect(stem.content).not_to be_blank
         expect(stem.stem_answers).not_to be_blank
-        expect(Set.new(stem.stem_answers.collect{ |sa| sa.answer })).to eq Set.new(question.answers)
+        expect(Set.new(stem.stem_answers.map { |sa| sa.answer })).to eq Set.new(question.answers)
         expect(stem.stem_answers.any?{ |answer| answer.correctness == 1.0 }).to eq true
 
         stem.stem_answers.each do |stem_answer|

--- a/spec/routines/exercises/import/quadbase_spec.rb
+++ b/spec/routines/exercises/import/quadbase_spec.rb
@@ -31,7 +31,7 @@ RSpec.describe Exercises::Import::Quadbase, type: :routine do
       expect(list.name).to eq 'Concept Coach'
 
       expect(exercise.tags).not_to be_blank
-      exercise.tags.map(&:name).each{ |tag_name| expect(expected_tags).to include(tag_name) }
+      exercise.tags.map(&:name).each { |tag_name| expect(expected_tags).to include(tag_name) }
 
       expect(exercise.stimulus).to be_in expected_exercise_stimuli
       expect(exercise.questions.length).to be > 0

--- a/spec/routines/exercises/import/quadbase_spec.rb
+++ b/spec/routines/exercises/import/quadbase_spec.rb
@@ -43,7 +43,7 @@ RSpec.describe Exercises::Import::Quadbase, type: :routine do
         stem = question.stems.first
         expect(stem.content).not_to be_blank
         expect(stem.stem_answers).not_to be_blank
-        expect(Set.new(stem.stem_answers.map{ |sa| sa.answer })).to eq Set.new(question.answers)
+        expect(Set.new(stem.stem_answers.map { |sa| sa.answer })).to eq Set.new(question.answers)
         expect(stem.stem_answers.any?{ |answer| answer.correctness == 1.0 }).to eq true
 
         stem.stem_answers.each do |stem_answer|

--- a/spec/routines/exercises/import/xlsx_spec.rb
+++ b/spec/routines/exercises/import/xlsx_spec.rb
@@ -53,7 +53,7 @@ RSpec.describe Exercises::Import::Xlsx, type: :routine do
       stem = question.stems.first
       expect(stem.content).not_to be_blank
       expect(stem.stem_answers).not_to be_blank
-      expect(Set.new(stem.stem_answers.collect{ |sa| sa.answer })).to eq Set.new(question.answers)
+      expect(Set.new(stem.stem_answers.map { |sa| sa.answer })).to eq Set.new(question.answers)
       expect(stem.stem_answers.any?{ |answer| answer.correctness == 1.0 }).to eq true
 
       stem.stem_answers.each do |stem_answer|

--- a/spec/routines/exercises/import/zip_spec.rb
+++ b/spec/routines/exercises/import/zip_spec.rb
@@ -24,7 +24,7 @@ RSpec.describe Exercises::Import::Zip, type: :routine do
 
       expect(exercise.tags).not_to be_blank
       expect(exercise.tags).to satisfy do |tags|
-        tag_names = tags.collect { |tag| tag.name }
+        tag_names = tags.map { |tag| tag.name }
         (tag_names & ['lo:k12phys:3-1-1',
                       'lo:k12phys:3-1-2',
                       'lo:k12phys:3-2-1',
@@ -49,7 +49,7 @@ RSpec.describe Exercises::Import::Zip, type: :routine do
       stem = question.stems.first
       expect(stem.content).not_to be_blank
       expect(stem.stem_answers).not_to be_blank
-      expect(Set.new(stem.stem_answers.collect{ |sa| sa.answer })).to eq Set.new(question.answers)
+      expect(Set.new(stem.stem_answers.map { |sa| sa.answer })).to eq Set.new(question.answers)
       expect(stem.stem_answers.any?{ |answer| answer.correctness == 1.0 }).to eq true
 
       stem.stem_answers.each do |stem_answer|

--- a/spec/routines/exercises/tag/xlsx_spec.rb
+++ b/spec/routines/exercises/tag/xlsx_spec.rb
@@ -17,7 +17,7 @@ RSpec.describe Exercises::Tag::Xlsx, type: :routine do
     ]
   end
 
-  let!(:exercises) { (1..6).map{ |i| FactoryBot.create(:publication, number: -i).publishable } }
+  let!(:exercises) { (1..6).map { |i| FactoryBot.create(:publication, number: -i).publishable } }
 
   it 'tags exercises with the sample spreadsheet' do
     expect { described_class.call(filename: fixture_path) }.to change{ ExerciseTag.count }.by(20)

--- a/spec/routines/exercises/tag/xlsx_spec.rb
+++ b/spec/routines/exercises/tag/xlsx_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Exercises::Tag::Xlsx, type: :routine do
     exercises.each do |exercise|
       expect(exercise.tags).not_to be_blank
       expect(exercise.tags).to satisfy do |tags|
-        tags.all{ |tag| expected_tags.include?(tag.name) }
+        tags.all { |tag| expected_tags.include?(tag.name) }
       end
     end
   end

--- a/spec/routines/exercises/untag/xlsx_spec.rb
+++ b/spec/routines/exercises/untag/xlsx_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Exercises::Untag::Xlsx, type: :routine do
 
     # Add the tags but don't publish the exercises
     Exercises::Tag::Xlsx.call(filename: @fixture_path)
-    @exercises.each{ |exercise| exercise.reload.publication.update_attribute :published_at, nil }
+    @exercises.each { |exercise| exercise.reload.publication.update_attribute :published_at, nil }
   end
 
   after(:all) { DatabaseCleaner.clean }
@@ -18,7 +18,7 @@ RSpec.describe Exercises::Untag::Xlsx, type: :routine do
   it 'removes exercise tags based on the sample spreadsheet' do
     expect { described_class.call(filename: @fixture_path) }.to change{ ExerciseTag.count }.by(-20)
 
-    @exercises.each{ |exercise| expect(exercise.reload.tags).to be_empty }
+    @exercises.each { |exercise| expect(exercise.reload.tags).to be_empty }
   end
 
   it 'skips exercises with no changes' do

--- a/spec/routines/exercises/untag/xlsx_spec.rb
+++ b/spec/routines/exercises/untag/xlsx_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Exercises::Untag::Xlsx, type: :routine do
   before(:all) do
     DatabaseCleaner.start
 
-    @exercises = (1..6).map{ |i| FactoryBot.create(:publication, number: -i).publishable }
+    @exercises = (1..6).map { |i| FactoryBot.create(:publication, number: -i).publishable }
 
     @fixture_path = 'spec/fixtures/sample_tags.xlsx'
 

--- a/spec/routines/search_exercises_spec.rb
+++ b/spec/routines/search_exercises_spec.rb
@@ -4,10 +4,10 @@ RSpec.describe SearchExercises, type: :routine do
   before do
     10.times { FactoryBot.create(:exercise, :published) }
 
-    tested_strings = ["%adipisci%", "%draft%"]
-    Exercise.joins{questions.outer.stems.outer}
-            .joins{questions.outer.answers.outer}
-            .where{(title.like_any tested_strings) |\
+    tested_strings = [ "%adipisci%", "%draft%" ]
+    Exercise.joins {questions.outer.stems.outer}
+            .joins {questions.outer.answers.outer}
+            .where {(title.like_any tested_strings) |\
                    (stimulus.like_any tested_strings) |\
                    (questions.stimulus.like_any tested_strings) |\
                    (stems.content.like_any tested_strings) |\

--- a/spec/routines/search_exercises_spec.rb
+++ b/spec/routines/search_exercises_spec.rb
@@ -14,50 +14,50 @@ RSpec.describe SearchExercises, type: :routine do
                    (answers.content.like_any tested_strings)}.delete_all
 
     @exercise_1 = Exercise.new
-    Api::V1::ExerciseRepresenter.new(@exercise_1).from_json({
-      tags: ['tag1', 'tag2'],
-      title: "Lorem ipsum",
-      stimulus: "Dolor",
-      questions: [{
-        stimulus: "Sit amet",
-        stem_html: "Consectetur adipiscing elit",
-        answers: [{
-          content_html: "Sed do eiusmod tempor"
+    Api::V1::ExerciseRepresenter.new(@exercise_1).from_hash(
+      'tags' => ['tag1', 'tag2'],
+      'title' => "Lorem ipsum",
+      'stimulus' => "Dolor",
+      'questions' => [{
+        'stimulus' => "Sit amet",
+        'stem_html' => "Consectetur adipiscing elit",
+        'answers' => [{
+          'content_html' => "Sed do eiusmod tempor"
         }]
       }]
-    }.to_json)
+    )
     @exercise_1.save!
     @exercise_1.publication.publish.save!
 
     @exercise_2 = Exercise.new
-    Api::V1::ExerciseRepresenter.new(@exercise_2).from_json({
-      tags: ['tag2', 'tag3'],
-      title: "Dolorem ipsum",
-      stimulus: "Quia dolor",
-      questions: [{
-        stimulus: "Sit amet",
-        stem_html: "Consectetur adipisci velit",
-        answers: [{
-          content_html: "Sed quia non numquam"
+    Api::V1::ExerciseRepresenter.new(@exercise_2).from_hash(
+      'tags' => ['tag2', 'tag3'],
+      'title' => "Dolorem ipsum",
+      'stimulus' => "Quia dolor",
+      'questions' => [{
+        'stimulus' => "Sit amet",
+        'stem_html' => "Consectetur adipisci velit",
+        'answers' => [{
+          'content_html' => "Sed quia non numquam"
         }]
       }]
-    }.to_json)
+    )
     @exercise_2.save!
     @exercise_2.publication.publish.save!
 
     @exercise_draft = FactoryBot.build(:exercise)
-    Api::V1::ExerciseRepresenter.new(@exercise_draft).from_json({
-      tags: ['all', 'the', 'tags'],
-      title: "DRAFT",
-      stimulus: "This is a draft",
-      questions: [{
-        stimulus: "with no collaborators",
-        stem_html: "and should not appear",
-        answers: [{
-          content_html: "in most searches"
+    Api::V1::ExerciseRepresenter.new(@exercise_draft).from_hash(
+      'tags' => ['all', 'the', 'tags'],
+      'title' => "DRAFT",
+      'stimulus' => "This is a draft",
+      'questions' => [{
+        'stimulus' => "with no collaborators",
+        'stem_html' => "and should not appear",
+        'answers' => [{
+          'content_html' => "in most searches"
         }]
       }]
-    }.to_json)
+    )
     @exercise_draft.save!
 
     @exercises_count = Exercise.count

--- a/spec/routines/search_vocab_terms_spec.rb
+++ b/spec/routines/search_vocab_terms_spec.rb
@@ -2,10 +2,10 @@ require "rails_helper"
 
 RSpec.describe SearchVocabTerms, type: :routine do
   before do
-    10.times{ FactoryBot.create(:vocab_term, :published) }
+    10.times { FactoryBot.create(:vocab_term, :published) }
 
     tested_strings = ["%lorem ipsu%", "%adipiscing elit%", "draft"]
-    VocabTerm.where{(name.like_any tested_strings) |
+    VocabTerm.where {(name.like_any tested_strings) |
                     (definition.like_any tested_strings)}.delete_all
 
     @vocab_term_1 = FactoryBot.build(:vocab_term, :published)

--- a/spec/routines/search_vocab_terms_spec.rb
+++ b/spec/routines/search_vocab_terms_spec.rb
@@ -9,30 +9,30 @@ RSpec.describe SearchVocabTerms, type: :routine do
                     (definition.like_any tested_strings)}.delete_all
 
     @vocab_term_1 = FactoryBot.build(:vocab_term, :published)
-    Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_1).from_json({
-      tags: ['tag1', 'tag2'],
-      term: "Lorem ipsum",
-      definition: "Dolor sit amet",
-      distractor_literals: ["Consectetur adipiscing elit", "Sed do eiusmod tempor"]
-    }.to_json)
+    Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_1).from_hash(
+      'tags' => ['tag1', 'tag2'],
+      'term' => "Lorem ipsum",
+      'definition' => "Dolor sit amet",
+      'distractor_literals' => ["Consectetur adipiscing elit", "Sed do eiusmod tempor"]
+    )
     @vocab_term_1.save!
 
     @vocab_term_2 = FactoryBot.build(:vocab_term, :published)
-    Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_2).from_json({
-      tags: ['tag2', 'tag3'],
-      term: "Dolorem ipsum",
-      definition: "Quia dolor sit amet",
-      distractor_literals: ["Consectetur adipisci velit", "Sed quia non numquam"]
-    }.to_json)
+    Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_2).from_hash(
+      'tags' => ['tag2', 'tag3'],
+      'term' => "Dolorem ipsum",
+      'definition' => "Quia dolor sit amet",
+      'distractor_literals' => ["Consectetur adipisci velit", "Sed quia non numquam"]
+    )
     @vocab_term_2.save!
 
     @vocab_term_draft = FactoryBot.build(:vocab_term)
-    Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_draft).from_json({
-      tags: ['all', 'the', 'tags'],
-      term: "draft",
-      definition: "Not ready for prime time",
-      distractor_literals: ["Release to production NOW"]
-    }.to_json)
+    Api::V1::VocabTermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_draft).from_hash(
+      'tags' => ['all', 'the', 'tags'],
+      'term' => "draft",
+      'definition' => "Not ready for prime time",
+      'distractor_literals' => ["Release to production NOW"]
+    )
     @vocab_term_draft.save!
 
     @vocab_terms_count = VocabTerm.count

--- a/vendor/assets/stylesheets/modern-buttons/m-buttons.css.scss
+++ b/vendor/assets/stylesheets/modern-buttons/m-buttons.css.scss
@@ -85,7 +85,7 @@ input[type="search"]::-webkit-search-decoration, input[type="search"]::-webkit-s
   filter: alpha(opacity=50);
   content: "\2193";  
 }
-.caret.white{
+.caret.white {
   border-left: 4px solid transparent;
   border-right: 4px solid transparent;
   border-top: 4px solid white;


### PR DESCRIPTION
The default behavior of Representable when setting collections is not ideal. If I remember right, it uses Object.collection= to set the collection, which produces useless error messages when validations fail. Some time ago, we had a card to fix those error messages, but that solution (replacing `collection=` with `<<`) had a few flaws, that I fixed in this PR and made into the `AR_COLLECTION_SETTER`. It should no longer duplicate the records when saving.