### PR TITLE
Fixed caching of available exercise versions

### DIFF
--- a/app/controllers/api/v1/attachments_controller.rb
+++ b/app/controllers/api/v1/attachments_controller.rb
@@ -46,7 +46,7 @@ module Api::V1
     protected
 
     def get_exercise
-      @exercise = Exercise.visible_for(current_api_user).with_id(params[:exercise_id]).first!
+      @exercise = Exercise.visible_for(user: current_api_user).with_id(params[:exercise_id]).first!
     end
 
   end

--- a/app/controllers/api/v1/community_solutions_controller.rb
+++ b/app/controllers/api/v1/community_solutions_controller.rb
@@ -82,7 +82,7 @@ module Api::V1
     protected
 
     def get_community_solution
-      @community_solution = CommunitySolution.visible_for(current_api_user)
+      @community_solution = CommunitySolution.visible_for(user: current_api_user)
                                              .with_id(params[:id]).first || \
         raise(ActiveRecord::RecordNotFound,
               "Couldn't find CommunitySolution with 'uid'=#{params[:id]}")

--- a/app/controllers/api/v1/exercises_controller.rb
+++ b/app/controllers/api/v1/exercises_controller.rb
@@ -147,7 +147,7 @@ module Api::V1
     protected
 
     def get_exercise
-      @exercise = Exercise.visible_for(current_api_user).with_id(params[:id]).first || \
+      @exercise = Exercise.visible_for(user: current_api_user).with_id(params[:id]).first || \
         raise(ActiveRecord::RecordNotFound, "Couldn't find Exercise with 'uid'=#{params[:id]}")
     end
 
@@ -162,7 +162,7 @@ module Api::V1
           if draft_requested
 
         # Attempt to find existing exercise
-        @exercise = Exercise.visible_for(current_api_user).with_id(params[:id]).first
+        @exercise = Exercise.visible_for(user: current_api_user).with_id(params[:id]).first
         return unless @exercise.nil?
 
         # Exercise not found and either draft not requested or

--- a/app/controllers/api/v1/publications_controller.rb
+++ b/app/controllers/api/v1/publications_controller.rb
@@ -45,19 +45,19 @@ module Api::V1
     protected
 
     def get_exercise
-      Exercise.visible_for(current_api_user).with_id(params[:exercise_id]).first ||
+      Exercise.visible_for(user: current_api_user).with_id(params[:exercise_id]).first ||
         raise(ActiveRecord::RecordNotFound,
               "Couldn't find Exercise with 'uid'=#{params[:exercise_id]}")
     end
 
     def get_vocab_term
-      VocabTerm.visible_for(current_api_user).with_id(params[:vocab_term_id]).first ||
+      VocabTerm.visible_for(user: current_api_user).with_id(params[:vocab_term_id]).first ||
         raise(ActiveRecord::RecordNotFound,
               "Couldn't find VocabTerm with 'uid'=#{params[:vocab_term_id]}")
     end
 
     def get_community_solution
-      CommunitySolution.visible_for(current_api_user)
+      CommunitySolution.visible_for(user: current_api_user)
                        .with_id(params[:community_solution_id]).first ||
         raise(ActiveRecord::RecordNotFound,
               "Couldn't find Solution with 'uid'=#{params[:community_solution_id]}")

--- a/app/controllers/api/v1/vocab_terms_controller.rb
+++ b/app/controllers/api/v1/vocab_terms_controller.rb
@@ -164,7 +164,7 @@ module Api::V1
     protected
 
     def get_vocab_term
-      @vocab_term = VocabTerm.visible_for(current_api_user).with_id(params[:id]).first || \
+      @vocab_term = VocabTerm.visible_for(user: current_api_user).with_id(params[:id]).first || \
         raise(ActiveRecord::RecordNotFound, "Couldn't find VocabTerm with 'uid'=#{params[:id]}")
     end
 
@@ -179,7 +179,7 @@ module Api::V1
           if draft_requested
 
         # Attempt to find existing vocab_term
-        @vocab_term = VocabTerm.visible_for(current_api_user).with_id(params[:id]).first
+        @vocab_term = VocabTerm.visible_for(user: current_api_user).with_id(params[:id]).first
         return unless @vocab_term.nil?
 
         # VocabTerm not found and either draft not requested or

--- a/app/models/community_solution.rb
+++ b/app/models/community_solution.rb
@@ -1,37 +1,4 @@
 class CommunitySolution < ActiveRecord::Base
   publishable
   solution
-
-  scope :visible_for, ->(user) {
-    user = user.human_user if user.is_a?(OpenStax::Api::ApiUser)
-    next none if !user.is_a?(User) || user.is_anonymous?
-    next all if user.administrator
-    user_id = user.id
-
-    joins do
-      [
-        publication.authors,
-        publication.copyright_holders,
-        publication.publication_group.list_publication_groups.outer.list.outer.list_owners,
-        publication.publication_group.list_publication_groups.outer.list.outer.list_editors,
-        publication.publication_group.list_publication_groups.outer.list.outer.list_readers
-      ].map(&:outer)
-    end.where do
-      (authors.user_id           == user_id                                        ) |
-      (copyright_holders.user_id == user_id                                        ) |
-      ((list_owners.owner_id     == user_id) & (list_owners.owner_type   == 'User')) |
-      ((list_editors.editor_id   == user_id) & (list_editors.editor_type == 'User')) |
-      ((list_readers.reader_id   == user_id) & (list_readers.reader_type == 'User'))
-    end
-  }
-  scope :visible_for, ->(user) {
-    user = user.human_user if user.is_a?(OpenStax::Api::ApiUser)
-    next none if !user.is_a?(User) || user.is_anonymous?
-    next all if user.administrator
-    user_id = user.id
-
-    joins{publication.authors.outer}
-      .joins {publication.copyright_holders.outer}
-      .where { (authors.user_id == user_id) | (copyright_holders.user_id == user_id) }
-  }
 end

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -55,7 +55,10 @@ class Publication < ActiveRecord::Base
     end.order {[publication_group.number.asc, version.desc]}
   end
 
-  scope :visible_for, ->(user) do
+  scope :visible_for, ->(options) do
+    next all if options[:can_view_solutions]
+
+    user = options[:user]
     user = user.human_user if user.is_a?(OpenStax::Api::ApiUser)
     next published if !user.is_a?(User) || user.is_anonymous?
     next all if user.administrator

--- a/app/representers/api/v1/exercises/representer.rb
+++ b/app/representers/api/v1/exercises/representer.rb
@@ -53,8 +53,9 @@ module Api::V1::Exercises
              type: Array,
              writeable: false,
              readable: true,
-             getter: ->(user_options:, **) { versions_visible_for(user_options[:user]) },
-             if: NOT_SOLUTIONS_ONLY
+             getter: ->(user_options:, **) do
+               visible_versions(can_view_solutions: SOLUTIONS.call(user_options: user_options))
+             end
 
     # Like Hash#deep_merge but also handles arrays
     def recursive_merge(enum1, enum2)
@@ -92,7 +93,7 @@ module Api::V1::Exercises
         super(options.merge(user_options: user_options.merge(solutions_only: true)))
       end
 
-      recursive_merge(no_solutions, solutions_only)
+      recursive_merge(no_solutions.except(:versions), solutions_only)
     end
 
   end

--- a/app/routines/search_exercises.rb
+++ b/app/routines/search_exercises.rb
@@ -20,7 +20,7 @@ class SearchExercises
 
   def exec(params = {}, options = {})
     params[:ob] ||= [{number: :asc}, {version: :desc}]
-    relation = Exercise.visible_for(options[:user]).joins(publication: :publication_group)
+    relation = Exercise.visible_for(options).joins(publication: :publication_group)
 
     distinct = false
     # By default, only return the latest exercises visible to the user.

--- a/app/routines/search_vocab_terms.rb
+++ b/app/routines/search_vocab_terms.rb
@@ -21,7 +21,7 @@ class SearchVocabTerms
 
   def exec(params = {}, options = {})
     params[:ob] ||= [{number: :asc}, {version: :desc}]
-    relation = VocabTerm.visible_for(options[:user]).joins(publication: :publication_group)
+    relation = VocabTerm.visible_for(options).joins(publication: :publication_group)
 
     distinct = false
     # By default, only return the latest exercises visible to the user.

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180131161240) do
+ActiveRecord::Schema.define(version: 20180220213530) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -491,10 +491,12 @@ ActiveRecord::Schema.define(version: 20180131161240) do
     t.datetime "updated_at",               null: false
     t.integer  "latest_version",           null: false
     t.integer  "latest_published_version"
+    t.string   "nickname"
   end
 
   add_index "publication_groups", ["id", "latest_published_version"], name: "index_publication_groups_on_id_and_latest_published_version", using: :btree
   add_index "publication_groups", ["id", "latest_version"], name: "index_publication_groups_on_id_and_latest_version", using: :btree
+  add_index "publication_groups", ["nickname"], name: "index_publication_groups_on_nickname", unique: true, using: :btree
   add_index "publication_groups", ["number", "publishable_type"], name: "index_publication_groups_on_number_and_publishable_type", unique: true, using: :btree
   add_index "publication_groups", ["publishable_type"], name: "index_publication_groups_on_publishable_type", using: :btree
   add_index "publication_groups", ["uuid"], name: "index_publication_groups_on_uuid", unique: true, using: :btree

--- a/spec/controllers/api/v1/exercises_controller_spec.rb
+++ b/spec/controllers/api/v1/exercises_controller_spec.rb
@@ -201,49 +201,63 @@ module Api::V1
         }
         expect(response).to have_http_status(:success)
         expect(response.body_as_hash).to match(a_hash_including(uuid: @exercise.uuid))
-        expect(response.body_as_hash[:versions]).to eq @exercise.versions_visible_for(user)
+        expect(response.body_as_hash[:versions]).to(
+          eq @exercise.visible_versions(can_view_solutions: true)
+        )
       end
 
       it "returns the Exercise requested by uuid" do
         api_get :show, user_token, parameters: { id: @exercise.uuid }
         expect(response).to have_http_status(:success)
         expect(response.body_as_hash).to match(a_hash_including(uuid: @exercise.uuid))
-        expect(response.body_as_hash[:versions]).to eq @exercise.versions_visible_for(user)
+        expect(response.body_as_hash[:versions]).to(
+          eq @exercise.visible_versions(can_view_solutions: true)
+        )
       end
 
       it "returns the Exercise requested by uid" do
         api_get :show, user_token, parameters: { id: @exercise.uid }
         expect(response).to have_http_status(:success)
         expect(response.body_as_hash).to match(a_hash_including(uuid: @exercise.uuid))
-        expect(response.body_as_hash[:versions]).to eq @exercise.versions_visible_for(user)
+        expect(response.body_as_hash[:versions]).to(
+          eq @exercise.visible_versions(can_view_solutions: true)
+        )
       end
 
       it "returns the latest published Exercise if only the group_uuid is specified" do
         api_get :show, user_token, parameters: { id: @exercise.group_uuid }
         expect(response).to have_http_status(:success)
         expect(response.body_as_hash).to match(a_hash_including(uuid: @exercise.uuid))
-        expect(response.body_as_hash[:versions]).to eq @exercise.versions_visible_for(user)
+        expect(response.body_as_hash[:versions]).to(
+          eq @exercise.visible_versions(can_view_solutions: true)
+        )
       end
 
       it "returns the latest published Exercise if only the number is specified" do
         api_get :show, user_token, parameters: { id: @exercise.number }
         expect(response).to have_http_status(:success)
         expect(response.body_as_hash).to match(a_hash_including(uuid: @exercise.uuid))
-        expect(response.body_as_hash[:versions]).to eq @exercise.versions_visible_for(user)
+        expect(response.body_as_hash[:versions]).to(
+          eq @exercise.visible_versions(can_view_solutions: true)
+        )
       end
 
       it "returns the latest draft Exercise if \"group_uuid@draft\" is requested" do
         api_get :show, user_token, parameters: { id: "#{@exercise.group_uuid}@draft" }
         expect(response).to have_http_status(:success)
         expect(response.body_as_hash).to match(a_hash_including(uuid: @exercise_2.uuid))
-        expect(response.body_as_hash[:versions]).to eq @exercise_2.versions_visible_for(user)
+        expect(response.body_as_hash[:versions]).to(
+          eq @exercise_2.visible_versions(can_view_solutions: true)
+        )
       end
 
       it "returns the latest draft Exercise if \"number@draft\" is requested" do
         api_get :show, user_token, parameters: { id: "#{@exercise.number}@draft" }
         expect(response).to have_http_status(:success)
         expect(response.body_as_hash).to match(a_hash_including(uuid: @exercise_2.uuid))
-        expect(response.body_as_hash[:versions]).to eq @exercise_2.versions_visible_for(user)
+        expect(response.body_as_hash[:versions]).to(
+          eq @exercise_2.visible_versions(can_view_solutions: true)
+        )
       end
 
       it "returns the latest version of a Exercise if \"@latest\" is requested" do
@@ -251,7 +265,9 @@ module Api::V1
         api_get :show, user_token, parameters: { id: "#{@exercise.number}@latest" }
         expect(response).to have_http_status(:success)
         expect(response.body_as_hash).to match(a_hash_including(uuid: @exercise_1.uuid))
-        expect(response.body_as_hash[:versions]).to eq @exercise_1.versions_visible_for(user)
+        expect(response.body_as_hash[:versions]).to(
+          eq @exercise_1.visible_versions(can_view_solutions: true)
+        )
       end
 
       it "creates a new draft version if no draft and \"@draft\" is requested" do
@@ -314,7 +330,7 @@ module Api::V1
           end
         end
 
-        it "includes versions of exercise" do
+        it "includes versions of the exercise" do
           api_get :show, user_token, parameters: { id: @exercise.uid }
           expect(response).to have_http_status(:success)
           expect(response.body_as_hash[:versions]).to(

--- a/spec/lib/publishable_spec.rb
+++ b/spec/lib/publishable_spec.rb
@@ -19,7 +19,11 @@ RSpec.describe Publishable, type: :lib do
     draft = publishable.new_version
     draft.save!
 
-    expect(publishable.versions_visible_for(user)).to eq [p2.version, p1.version]
-    expect(publishable.versions_visible_for(author)).to eq [draft.version, p2.version, p1.version]
+    expect(publishable.visible_versions(can_view_solutions: false)).to(
+      eq [p2.version, p1.version]
+    )
+    expect(publishable.visible_versions(can_view_solutions: true)).to(
+      eq [draft.version, p2.version, p1.version]
+    )
   end
 end


### PR DESCRIPTION
Fixed a bug in how we were caching the array of available exercise versions. The versions visible to each user might be different, so we need to cache both the low-permission versions and the high-permission versions, then merge as needed.