### PR TITLE
Don't make requests to S3 when rendering exercises

### DIFF
--- a/app/representers/api/v1/attachment_representer.rb
+++ b/app/representers/api/v1/attachment_representer.rb
@@ -12,7 +12,18 @@ module Api::V1
              type: String,
              readable: true,
              writeable: false,
-             getter: ->(*) { { filename: read_attribute(:asset) }.merge asset.as_json },
+             getter: ->(*) do
+               host = AssetUploader.asset_host
+               filename = read_attribute(:asset)
+
+               {
+                 filename: filename,
+                 url:      "#{host}/attachments/#{filename}",
+                 large:    { url: "#{host}/attachments/large_#{filename}" },
+                 medium:   { url: "#{host}/attachments/medium_#{filename}" },
+                 small:    { url: "#{host}/attachments/small_#{filename}" }
+               }
+             end,
              schema_info: {
                required: true
              }


### PR DESCRIPTION
By manually recreating `asset.as_json` without calling the `asset` method.