### PR TITLE
Display only latest version + potentially draft when searching by ID w/o specific version

### DIFF
--- a/app/routines/search_exercises.rb
+++ b/app/routines/search_exercises.rb
@@ -40,6 +40,10 @@ class SearchExercises
 
           sanitized_numbers = sanitized_ids.map(&:first).compact
           sanitized_versions = sanitized_ids.map(&:second).compact
+
+          # Disable "latest_visible" if any version is specified
+          latest_visible = false unless sanitized_versions.empty?
+
           if sanitized_numbers.empty?
             @items = @items.where(publications: { version: sanitized_versions })
           elsif sanitized_versions.empty?
@@ -73,9 +77,6 @@ class SearchExercises
             end
           end
         end
-
-        # Since we are returning specific ids, disable "latest_visible"
-        latest_visible = false
       end
 
       with.default_keyword :content

--- a/app/routines/search_vocab_terms.rb
+++ b/app/routines/search_vocab_terms.rb
@@ -41,6 +41,10 @@ class SearchVocabTerms
 
           sanitized_numbers = sanitized_ids.map(&:first).compact
           sanitized_versions = sanitized_ids.map(&:second).compact
+
+          # Disable "latest_visible" if any version is specified
+          latest_visible = false unless sanitized_versions.empty?
+
           if sanitized_numbers.empty?
             @items = @items.where(publications: { version: sanitized_versions })
           elsif sanitized_versions.empty?
@@ -74,9 +78,6 @@ class SearchVocabTerms
             end
           end
         end
-
-        # Since we are returning specific uids, disable "latest_visible"
-        latest_visible = false
       end
 
       # Block to be used for searches by name or term


### PR DESCRIPTION
Fix for SMEs seeing too many versions when searching.

Manually tested on -qa