### PR TITLE
update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ See [OpenStax Swerve](http://github.com/openstax/swerve) for more information.
 
 ```sh
 $ bundle --without production
+$ createuser --superuser ox_exercises
+$ createdb ox_exercises_dev
 $ rake db:migrate
 $ rake db:seed
 $ rails s


### PR DESCRIPTION
When trying to get exercises to run, I couldn’t run `rake db:migrate` without first running `createuser --superuser ox_exercises` and `createdb ox_exercises_dev` 