### PR TITLE
Exercise attachment saving

### DIFF
--- a/app/uploaders/asset_uploader.rb
+++ b/app/uploaders/asset_uploader.rb
@@ -51,7 +51,7 @@ class AssetUploader < CarrierWave::Uploader::Base
     when CarrierWave::SanitizedFile
       file.to_file
     when CarrierWave::Storage::Fog::File
-      CarrierWave::Storage::Fog.new(self).retrieve!(File.basename(file.path))
+      file.read
     else
       open(file)
     end

--- a/lib/has_attachments.rb
+++ b/lib/has_attachments.rb
@@ -3,7 +3,7 @@ module HasAttachments
     module Base
       def has_attachments
         class_exec do
-          has_many :attachments, as: :parent, dependent: :destroy, inverse_of: :parent, validate: false
+          has_many :attachments, as: :parent, dependent: :destroy, inverse_of: :parent
         end
       end
     end


### PR DESCRIPTION
This works around an incompatibility between carrierwave-fog-aws and mimemagic 0.3.3 (Why were we using mimemagic from > 2 years ago, anyway?)

Also removes the 'continue even if  attachment is invalid' save behavior, since that was deleting attachments (even valid ones?)