### PR TITLE
Disable ActiveStorage routes since we currently do not use them

### DIFF
--- a/config/initializers/active_storage.rb
+++ b/config/initializers/active_storage.rb
@@ -1,0 +1,3 @@
+# Disable ActiveStorage routes since we currently do not use it
+# https://stackoverflow.com/a/53159319
+Rails.application.routes_reloader.paths.delete_if { |path| path =~ /activestorage/ }


### PR DESCRIPTION
One thing we missed during the Rails 5 upgrade. I'll do the same in Tutor.

These routes currently don't work anyway because Rails puts them after the catch-all FE route.