### PR TITLE
Fix admin views blowing up due to users with nil username

### DIFF
--- a/app/views/shared/users/_index.html.erb
+++ b/app/views/shared/users/_index.html.erb
@@ -15,7 +15,7 @@
       data_procs:
         [
           ->(user) do
-            short_username = user.username.truncate(32)
+            short_username = user.username&.truncate(32)
             sign_in_as ?
               link_to(short_username, become_admin_user_url(user), method: :put) : short_username
           end,

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     deleted_at { nil }
 
     transient do
-      username   { Faker::Lorem.characters }
+      username   { [Faker::Lorem.characters, nil].sample }
       first_name { Faker::Name.first_name }
       last_name  { Faker::Name.last_name }
       full_name  { "#{first_name} #{last_name}" }


### PR DESCRIPTION
- Change shared view so it doesn't blow up on nil username
- Ensure we test users with nil username by changing the factory