### PR TITLE
Reorder delegation form and search form in admin delegations view

### DIFF
--- a/app/views/admin/delegations/_form.html.erb
+++ b/app/views/admin/delegations/_form.html.erb
@@ -8,26 +8,6 @@
   (so error messages render properly)
 %>
 
-<div class='form-inline'>
-  <%=
-    render partial: 'openstax/accounts/shared/accounts/search', locals: {
-      search_action_path: users_admin_delegations_url,
-      action_partial: 'admin/delegations/actions',
-      action_heading: 'Make',
-      remote: true
-    }
-  %>
-</div>
-
-<div id='search-results-list'>
-  <%=
-    render partial: 'shared/users/search_results', locals: {
-      action_partial: 'admin/delegations/actions',
-      action_heading: 'Make'
-    }
-  %>
-</div>
-
 <%= form_with model: [:admin, delegation], local: true do |form| %>
   <%= render partial: 'shared/error_messages', locals: { target: delegation } %>
 
@@ -83,3 +63,25 @@
 
   <%= form.submit class: 'btn btn-primary' %>
 <% end %>
+
+<br>
+
+<div class='form-inline'>
+  <%=
+    render partial: 'openstax/accounts/shared/accounts/search', locals: {
+      search_action_path: users_admin_delegations_url,
+      action_partial: 'admin/delegations/actions',
+      action_heading: 'Make',
+      remote: true
+    }
+  %>
+</div>
+
+<div id='search-results-list'>
+  <%=
+    render partial: 'shared/users/search_results', locals: {
+      action_partial: 'admin/delegations/actions',
+      action_heading: 'Make'
+    }
+  %>
+</div>


### PR DESCRIPTION
Turns out having a big list of users above a form means the form is pushed outside the screen.
Also links on the user list make the page scroll back to the top, causing the user not to see what the links are doing.
Fixed by moving the list of users to below the delegation form.