### PR TITLE
Invalidate cache when mass updating publishables

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
     - PARALLEL_TEST_PROCESSORS=2
   matrix:
     - ASSETS=true
-    - TAG=speed:fast
-    - TAG=~speed:fast
+    - TAG=speed:slow
+    - TAG=~speed:slow
 rvm: 2.6.1
 cache: bundler
 before_install:

--- a/spec/routines/exercises/import/old/xlsx_spec.rb
+++ b/spec/routines/exercises/import/old/xlsx_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module Exercises::Import
-  RSpec.describe Old::Xlsx, type: :routine do
+  RSpec.describe Old::Xlsx, type: :routine, speed: :slow do
     let(:fixture_path) { 'spec/fixtures/old/sample_exercises.xlsx' }
 
     let(:expected_los) {
@@ -60,11 +60,11 @@ module Exercises::Import
     it 'skips exercises with no changes' do
       expect {
         described_class.call(filename: fixture_path, author_id: author.id, ch_id: ch.id)
-      }.to change{ Exercise.count }.by(128)
+      }.to change { Exercise.count }.by(128)
 
       expect {
         described_class.call(filename: fixture_path, author_id: author.id, ch_id: ch.id)
-      }.not_to change{ Exercise.count }
+      }.not_to change { Exercise.count }
     end
   end
 end

--- a/spec/routines/exercises/import/old/zip_spec.rb
+++ b/spec/routines/exercises/import/old/zip_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 module Exercises::Import
-  RSpec.describe Old::Zip, type: :routine do
+  RSpec.describe Old::Zip, type: :routine, speed: :slow do
     let(:fixture_path) { 'spec/fixtures/old/sample_exercises.zip' }
 
     let(:author) { FactoryBot.create :user }

--- a/spec/routines/exercises/import/quadbase_spec.rb
+++ b/spec/routines/exercises/import/quadbase_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Exercises::Import::Quadbase, type: :routine do
+RSpec.describe Exercises::Import::Quadbase, type: :routine, speed: :slow do
   let(:fixture_path) { 'spec/fixtures/quadbase.json' }
 
   let(:expected_exercise_stimuli) {
@@ -59,10 +59,10 @@ RSpec.describe Exercises::Import::Quadbase, type: :routine do
   it 'skips exercises with no changes' do
     expect {
       described_class.call(filename: fixture_path, book_name: 'physics')
-    }.to change{ Exercise.count }.by(2)
+    }.to change { Exercise.count }.by(2)
 
     expect {
       described_class.call(filename: fixture_path, book_name: 'physics')
-    }.not_to change{ Exercise.count }
+    }.not_to change { Exercise.count }
   end
 end

--- a/spec/routines/exercises/import/xlsx_spec.rb
+++ b/spec/routines/exercises/import/xlsx_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Exercises::Import::Xlsx, type: :routine do
+RSpec.describe Exercises::Import::Xlsx, type: :routine, speed: :slow do
   let(:fixture_path) { 'spec/fixtures/sample_exercises.xlsx' }
 
   let(:expected_los) {
@@ -68,10 +68,10 @@ RSpec.describe Exercises::Import::Xlsx, type: :routine do
   it 'skips exercises with no changes' do
     expect {
       described_class.call(filename: fixture_path, author_id: author.id, ch_id: ch.id)
-    }.to change{ Exercise.count }.by(200)
+    }.to change { Exercise.count }.by(200)
 
     expect {
       described_class.call(filename: fixture_path, author_id: author.id, ch_id: ch.id)
-    }.not_to change{ Exercise.count }
+    }.not_to change { Exercise.count }
   end
 end

--- a/spec/routines/exercises/import/zip_spec.rb
+++ b/spec/routines/exercises/import/zip_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe Exercises::Import::Zip, type: :routine do
+RSpec.describe Exercises::Import::Zip, type: :routine, speed: :slow do
   let(:fixture_path) { 'spec/fixtures/sample_exercises.zip' }
 
   let(:author) { FactoryBot.create :user }

--- a/spec/routines/vocab_terms/import/xlsx_spec.rb
+++ b/spec/routines/vocab_terms/import/xlsx_spec.rb
@@ -1,6 +1,6 @@
 require 'rails_helper'
 
-RSpec.describe VocabTerms::Import::Xlsx, type: :routine do
+RSpec.describe VocabTerms::Import::Xlsx, type: :routine, speed: :slow do
   let(:fixture_path) { 'spec/fixtures/sample_vocab_terms.xlsx' }
 
   let(:expected_names) {
@@ -67,10 +67,10 @@ RSpec.describe VocabTerms::Import::Xlsx, type: :routine do
   it 'skips vocab_terms with no changes' do
     expect {
       described_class.call(filename: fixture_path, author_id: author.id, ch_id: ch.id)
-    }.to change{ VocabTerm.count }.by(8)
+    }.to change { VocabTerm.count }.by(8)
 
     expect {
       described_class.call(filename: fixture_path, author_id: author.id, ch_id: ch.id)
-    }.not_to change{ VocabTerm.count }
+    }.not_to change { VocabTerm.count }
   end
 end


### PR DESCRIPTION
Necessary so the changes are visible after the updates.