### PR TITLE
Fixed the exercises migration to remove Accounts groups

### DIFF
--- a/db/migrate/20191126001003_drop_accounts_groups.openstax_accounts.rb
+++ b/db/migrate/20191126001003_drop_accounts_groups.openstax_accounts.rb
@@ -5,7 +5,9 @@ class DropAccountsGroups < ActiveRecord::Migration[5.2]
       dir.up do
         app_admin = User.joins(:account).find_by(account: { username: 'ose_app_admin' })
 
-        Doorkeeper::Application.update_all(owner: app_admin) if app_admin.present?
+        Doorkeeper::Application.where(owner_type: 'OpenStax::Accounts::Group').update_all(
+          owner_id: app_admin.id, owner_type: 'User'
+        ) if app_admin.present?
       end
     end
 


### PR DESCRIPTION
For whatever reason it's not figuring out that owner is polymorphic.