### PR TITLE
Fix publishables returned by with_id when given a UUID that starts with a digit

### DIFF
--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -1,7 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Exercise, type: :model do
-
   subject(:exercise) { FactoryBot.create :exercise }
 
   it { is_expected.to have_many(:questions).dependent(:destroy).autosave(true) }
@@ -74,5 +73,4 @@ RSpec.describe Exercise, type: :model do
       expect(exercise.can_view_solutions?(user)).to eq false
     end
   end
-
 end

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -1,4 +1,4 @@
-require "rails_helper"
+require 'rails_helper'
 
 RSpec.describe Publication, type: :model do
   subject(:publication) { FactoryBot.create :publication }


### PR DESCRIPTION
Feeding it directly to the `where` apparently uses `to_i` to turn it into a number which is bad.
We want `Integer(...) rescue nil` instead