### PR TITLE
Fixed error on API calls like /api/exercises/number

### DIFF
--- a/lib/publishable/active_record.rb
+++ b/lib/publishable/active_record.rb
@@ -36,7 +36,9 @@ module Publishable
 
             rel = case version
             when NilClass
-              join_rel.where(publication: { uuid: number_or_uuid }).or(or_rel.published)
+              join_rel.where(publication: { uuid: number_or_uuid }).or(
+                or_rel.where.not(publication: { published_at: nil })
+              )
             when 'draft', 'd'
               or_rel.unpublished
             when 'latest'

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -24,8 +24,8 @@ RSpec.describe Publication, type: :model do
 
     it 'can return publications by id' do
       new_version
-      #expect(described_class.with_id(publication.number)).to eq [ publication ]
-      #expect(described_class.with_id(publication.publication_group.uuid)).to eq [ publication ]
+      expect(described_class.with_id(publication.number)).to eq [ publication ]
+      expect(described_class.with_id(publication.publication_group.uuid)).to eq [ publication ]
       expect(described_class.with_id(publication.uuid)).to eq [ publication ]
       expect(described_class.with_id(publication.uid)).to eq [ publication ]
       expect(described_class.with_id("#{publication.number}@draft")).to eq [ new_version ]
@@ -35,7 +35,7 @@ RSpec.describe Publication, type: :model do
       )
     end
 
-    it 'knows which users can view it' do
+    it 'can determine versions visible for a user' do
       user = FactoryBot.create :user
       admin = FactoryBot.create :user, :administrator
       author = FactoryBot.create(:author, publication: publication).user


### PR DESCRIPTION
Even though the publication tests for this were commented out, the method worked at the publication level.
The new publishable tests I added do catch the error, though.