### PR TITLE
Redirect to login if non-logged-in user tries to access status page

### DIFF
--- a/config/initializers/openstax_utilities.rb
+++ b/config/initializers/openstax_utilities.rb
@@ -1,5 +1,9 @@
 OpenStax::Utilities.configure do |config|
   config.status_authenticate = -> do
-    raise SecurityTransgression unless current_user.is_administrator?
+    authenticate_user!
+
+    next if performed? || current_user.is_administrator?
+
+    raise SecurityTransgression
   end
 end


### PR DESCRIPTION
Convenience for admins