### PR TITLE
Fixed the new exercise link to match what the frontend expects

### DIFF
--- a/app/views/layouts/_application_header.html.erb
+++ b/app/views/layouts/_application_header.html.erb
@@ -23,7 +23,7 @@
             <%= render 'layouts/application_top_nav_link',
                        target_text:           'WRITE A NEW EXERCISE',
                        target_id:             'top-nav-exercises-new-link',
-                       target_path:           'exercises/new',
+                       target_path:           'exercise/new',
                        target_current_symbol: :top_nav_exercises_new_current %>
           </li>
           <li>


### PR DESCRIPTION
The new exercise dialog currently doesn't open when you click the link because the url is wrong.