### PR TITLE
Added gems to create RDS snapshots before migrations

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,9 +17,10 @@ gem 'bootstrap-sass'
 # Use SCSS for stylesheets
 gem 'sass-rails', '~> 5.0'
 
-# Use Uglifier as compressor for JavaScript assets
+# Use Uglifier as compressor for JS assets
 gem 'uglifier', '>= 1.3.0'
 
+# V8 bindings to precompile JS assets
 gem 'mini_racer'
 
 # Use jquery as the JavaScript library
@@ -220,9 +221,11 @@ group :test do
 end
 
 group :production do
-  # Used to fetch secrets from the AWS parameter store and secrets manager
-  gem 'aws-sdk-ssm', require: false
-  gem 'aws-sdk-secretsmanager', require: false
+  # Used to backup the database before migrations
+  gem 'aws-sdk-rds', require: false
+
+  # Used to record a lifecycle action heartbeat after creating the RDS snapshot before migrating
+  gem 'aws-sdk-autoscaling', require: false
 
   # Fog AWS
   gem 'fog-aws'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -98,15 +98,12 @@ GEM
     aws-sdk-kms (1.42.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
+    aws-sdk-rds (1.131.0)
+      aws-sdk-core (~> 3, >= 3.122.0)
+      aws-sigv4 (~> 1.1)
     aws-sdk-s3 (1.88.0)
       aws-sdk-core (~> 3, >= 3.112.0)
       aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-secretsmanager (1.44.0)
-      aws-sdk-core (~> 3, >= 3.112.0)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-ssm (1.104.0)
-      aws-sdk-core (~> 3, >= 3.112.0)
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.4.0)
       aws-eventstream (~> 1, >= 1.0.2)
@@ -540,9 +537,9 @@ DEPENDENCIES
   addressable
   apipie-rails
   autoprefixer-rails
+  aws-sdk-autoscaling
+  aws-sdk-rds
   aws-sdk-s3
-  aws-sdk-secretsmanager
-  aws-sdk-ssm
   bootsnap (~> 1.4.0)
   bootstrap-sass
   brakeman


### PR DESCRIPTION
- Add aws-sdk-rds to backup the DB before migrating
- Add aws-sdk-autoscaling to record a lifecycle action heartbeat after creating the RDS snapshot before migrating
- Remove unused aws-sdk-ssm and aws-sdk-secretsmanager