### PR TITLE
Don't error on git-hosted entries in the ABL

### DIFF
--- a/app/controllers/api/v1/books_controller.rb
+++ b/app/controllers/api/v1/books_controller.rb
@@ -19,6 +19,8 @@ module Api::V1
       OSU::AccessPolicy.require_action_allowed! :index, current_api_user, OpenStax::Content::Book
 
       books = abl.approved_books.flat_map do |approved_book|
+        next [] if approved_book[:books].nil?
+
         approved_book[:books].map do |book|
           uuid = book[:uuid]
           versions = available_book_versions_by_uuid[uuid]


### PR DESCRIPTION
The new ABL was breaking Exercises:
https://sentry.io/organizations/openstax/issues/2849907256/?project=5563599