### PR TITLE
Speed up the slug tags migration

### DIFF
--- a/app/models/exercise.rb
+++ b/app/models/exercise.rb
@@ -155,8 +155,6 @@ class Exercise < ApplicationRecord
     end
   end
 
-  protected
-
   def has_questions
     return unless questions.first.nil?
     errors.add(:questions, "can't be blank")

--- a/db/migrate/20220302162344_create_slug_tags.rb
+++ b/db/migrate/20220302162344_create_slug_tags.rb
@@ -4,8 +4,8 @@ class CreateSlugTags < ActiveRecord::Migration[6.1]
   def up
     Exercise.preload(:publication).in_batches(of: 100, load: true) do |exercises|
       Exercise.transaction do
-        exercises.each(&:save) # creates the slug tags but does not set updated_at
-        exercises.update_all(updated_at: Time.current) # invalidates the exercise cache
+        exercises.each(&:set_slug_tags)
+        exercises.update_all updated_at: Time.current
       end
     end
   end


### PR DESCRIPTION
Turns out `set_context` takes a long time to run on every single exercise, so skip it and the rest of the validations and just run `set_slug_tags` on everything.

The tags autosave since they are a separate relation.