### PR TITLE
Added whenever gem to update slug tags every day and sync user names with Accounts

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -154,6 +154,9 @@ gem 'activerecord-import'
 # Get env variables from .env file
 gem 'dotenv-rails'
 
+# Cron job scheduling
+gem 'whenever'
+
 group :development, :test do
   # Run specs in parallel
   gem 'parallel_tests'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -119,6 +119,7 @@ GEM
     cheat (1.3.3)
       pager (~> 1.0)
     choice (0.2.0)
+    chronic (0.10.2)
     codecov (0.2.12)
       json
       simplecov
@@ -524,6 +525,8 @@ GEM
     websocket-driver (0.7.5)
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)
+    whenever (1.0.0)
+      chronic (>= 0.6.3)
     zeitwerk (2.5.1)
 
 PLATFORMS
@@ -607,6 +610,7 @@ DEPENDENCIES
   vcr
   web-console
   webmock
+  whenever
 
 BUNDLED WITH
    2.3.7

--- a/app/routines/update_slugs.rb
+++ b/app/routines/update_slugs.rb
@@ -1,0 +1,16 @@
+class UpdateSlugs
+  lev_routine transaction: :no_transaction
+
+  protected
+
+  def exec
+    Exercise.preload(:publication).in_batches(of: 100, load: true) do |exercises|
+      Exercise.transaction do
+        updated_exercise_ids = exercises.filter(&:set_slug_tags!).map(&:id)
+        next if updated_exercise_ids.empty?
+
+        Exercise.where(id: updated_exercise_ids).update_all updated_at: Time.current
+      end
+    end
+  end
+end

--- a/app/routines/update_slugs.rb
+++ b/app/routines/update_slugs.rb
@@ -6,7 +6,7 @@ class UpdateSlugs
   def exec
     Exercise.preload(:publication).in_batches(of: 100, load: true) do |exercises|
       Exercise.transaction do
-        updated_exercise_ids = exercises.filter(&:set_slug_tags!).map(&:id)
+        updated_exercise_ids = exercises.select(:id).filter(&:set_slug_tags!).map(&:id)
         next if updated_exercise_ids.empty?
 
         Exercise.where(id: updated_exercise_ids).update_all updated_at: Time.current

--- a/config/schedule.rb
+++ b/config/schedule.rb
@@ -1,0 +1,5 @@
+# Server time is UTC
+# Times below are interpreted that way
+
+every(1.minute)          { rake 'cron:minute' }
+every(1.day, at: '8 AM') { rake 'cron:day'    }  # Midnight-1AM Pacific/2-3AM Central/3-4AM Eastern

--- a/db/migrate/20220302162344_create_slug_tags.rb
+++ b/db/migrate/20220302162344_create_slug_tags.rb
@@ -4,7 +4,7 @@ class CreateSlugTags < ActiveRecord::Migration[6.1]
   def up
     Exercise.preload(:publication).in_batches(of: 100, load: true) do |exercises|
       Exercise.transaction do
-        exercises.each(&:set_slug_tags)
+        exercises.each(&:set_slug_tags!)
         exercises.update_all updated_at: Time.current
       end
     end

--- a/lib/tasks/cron/day.rake
+++ b/lib/tasks/cron/day.rake
@@ -1,0 +1,10 @@
+namespace :cron do
+  task day: :log_to_stdout do
+    Rails.logger.debug 'Starting daily cron'
+
+    Rails.logger.info 'UpdateSlugs.call'
+    OpenStax::RescueFrom.this { UpdateSlugs.call }
+
+    Rails.logger.debug 'Finished daily cron'
+  end
+end

--- a/lib/tasks/cron/minute.rake
+++ b/lib/tasks/cron/minute.rake
@@ -1,0 +1,10 @@
+namespace :cron do
+  task minute: :log_to_stdout do
+    Rails.logger.debug 'Starting minute cron'
+
+    Rails.logger.info 'rake openstax:accounts:sync:accounts'
+    OpenStax::RescueFrom.this { Rake::Task['openstax:accounts:sync:accounts'].invoke }
+
+    Rails.logger.debug 'Finished minute cron'
+  end
+end

--- a/lib/tasks/log_to_stdout.rake
+++ b/lib/tasks/log_to_stdout.rake
@@ -1,0 +1,20 @@
+# http://jerryclinesmith.me/blog/2014/01/16/logging-from-rake-tasks/
+desc 'Include this task as another task\'s dependency to cause Rails.logger to also print to STDOUT'
+task :log_to_stdout, [ :log_level ] => :environment do |tt, args|
+  # Do nothing in the test environment, since we don't want stdout there
+  next if Rails.env.test?
+
+  # Clone the main Rails logger to dissociate it from the other module loggers
+  # so we don't receive database, background job and mailer logs
+  Rails.logger = Rails.logger.clone
+
+  stdout_logger = ActiveSupport::Logger.new(STDOUT)
+
+  # By default, use a log level of at least 1 so we don't receive debug messages
+  stdout_logger.level = args.fetch(:log_level) do
+    ENV.fetch('LOG_LEVEL') { [ Rails.logger.level, 1 ].max }
+  end
+  stdout_logger.formatter = Rails.logger.formatter
+
+  Rails.logger.extend(ActiveSupport::Logger.broadcast(stdout_logger))
+end

--- a/spec/lib/tasks/cron/day.rake_spec.rb
+++ b/spec/lib/tasks/cron/day.rake_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'cron:day', type: :rake do
+  before :all do
+    Rake.application.rake_require 'tasks/cron/day'
+    Rake::Task.define_task :log_to_stdout
+  end
+
+  before { Rake::Task['cron:day'].reenable }
+
+  it 'calls the UpdateSlugs lev routine' do
+    expect(UpdateSlugs).to receive(:call)
+
+    Rake.application.invoke_task 'cron:day'
+  end
+end

--- a/spec/lib/tasks/cron/minute.rake_spec.rb
+++ b/spec/lib/tasks/cron/minute.rake_spec.rb
@@ -1,0 +1,20 @@
+require 'rails_helper'
+require 'rake'
+
+RSpec.describe 'cron:minute', type: :rake do
+  before :all do
+    Rake.application.rake_require 'tasks/cron/minute'
+    Rake::Task.define_task :log_to_stdout
+  end
+
+  before { Rake::Task['cron:minute'].reenable }
+
+  let!(:task) { instance_double(Rake::Task) }
+
+  it 'calls the openstax:accounts:sync rake task' do
+    expect(Rake::Task).to receive(:[]).with('openstax:accounts:sync:accounts').and_return(task)
+    expect(task).to receive(:invoke)
+
+    Rake.application.invoke_task 'cron:minute'
+  end
+end

--- a/spec/models/exercise_spec.rb
+++ b/spec/models/exercise_spec.rb
@@ -8,7 +8,8 @@ RSpec.describe Exercise, type: :model, vcr: VCR_OPTS do
   it { is_expected.to have_many(:exercise_tags).dependent(:destroy) }
 
   it 'automatically sets the context based on tags and rewrites image links' do
-    expect_any_instance_of(Exercise).to receive(:set_slug_tags).twice
+    # Disable set_slug_tags!
+    expect_any_instance_of(Exercise).to receive(:set_slug_tags!).twice
 
     exercise.tags = [
       'context-cnxmod:4ee317f2-cc23-4075-b377-51ee4d11bb61',

--- a/spec/routines/exercises/tag/xlsx_spec.rb
+++ b/spec/routines/exercises/tag/xlsx_spec.rb
@@ -20,8 +20,8 @@ RSpec.describe Exercises::Tag::Xlsx, type: :routine do
 
   let!(:exercises) { (1..6).map { |ii| FactoryBot.create(:publication, number: ii).publishable } }
 
-  # Disable set_slug_tags
-  before { allow_any_instance_of(Exercise).to receive(:set_slug_tags) }
+  # Disable set_slug_tags!
+  before { allow_any_instance_of(Exercise).to receive(:set_slug_tags!) }
 
   it 'tags exercises with the sample spreadsheet' do
     expect { described_class.call(filename: fixture_path) }.to change { ExerciseTag.count }.by(20)

--- a/spec/routines/exercises/untag/xlsx_spec.rb
+++ b/spec/routines/exercises/untag/xlsx_spec.rb
@@ -2,8 +2,8 @@ require 'rails_helper'
 
 RSpec.describe Exercises::Untag::Xlsx, type: :routine do
   before do
-    # Disable set_slug_tags
-    allow_any_instance_of(Exercise).to receive(:set_slug_tags)
+    # Disable set_slug_tags!
+    allow_any_instance_of(Exercise).to receive(:set_slug_tags!)
 
     @exercises = (1..6).map { |ii| FactoryBot.create(:publication, number: ii).publishable }
 

--- a/spec/routines/update_slugs_spec.rb
+++ b/spec/routines/update_slugs_spec.rb
@@ -1,0 +1,17 @@
+require 'rails_helper'
+
+RSpec.describe UpdateSlugs, type: :routine do
+  let!(:exercise)         { FactoryBot.create :exercise }
+  let!(:updated_exercise) { FactoryBot.create :exercise }
+
+  before do
+    allow_any_instance_of(Exercise).to(
+      receive(:set_slug_tags!) { |exercise| exercise.id == updated_exercise.id }
+    )
+  end
+
+  it 'calls set_slug_tags! on all exercises and sets updated_at for updated exercises' do
+    expect { described_class.call }.to  change     { updated_exercise.reload.updated_at }
+                                   .and not_change { exercise.reload.updated_at         }
+  end
+end


### PR DESCRIPTION
Good in case the ABL changes or users update their profiles in Accounts.
Also renamed set_slug_tags to indicate it has side-effects.