### PR TITLE
Improve handling of archive versions missing certain books

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -318,7 +318,7 @@ GEM
       roar
       roar-rails (>= 1)
       uber
-    openstax_content (1.1.0)
+    openstax_content (1.2.0)
       aws-sdk-s3
       faraday
       nokogiri

--- a/lib/content.rb
+++ b/lib/content.rb
@@ -6,19 +6,43 @@ module Content
       "slugs_by_page_uuid/#{OpenStax::Content::Abl.new.digest}"
     ) do
       {}.tap do |hash|
-        OpenStax::Content::Abl.new.approved_books.each do |book|
-          begin
-            pages = book.all_pages
-          rescue StandardError => exception
-            # Sometimes books in the ABL fail to load
-            # Log it, but keep going
-            Rails.logger.error exception
-          else
-            pages.each do |page|
-              hash[page.uuid] ||= []
-              hash[page.uuid] << { book: book.slug, page: page.slug }
+        books = OpenStax::Content::Abl.new.approved_books
+
+        until books.empty?
+          previous_version = nil
+          previous_archive = nil
+          retry_books = []
+
+          books.each do |book|
+            begin
+              pages = book.all_pages
+            rescue StandardError => exception
+              # Sometimes books in the ABL fail to load
+              # Retry with an earlier version of archive, if possible
+              previous_version ||= book.archive.previous_version
+
+              if previous_version.nil?
+                raise exception
+              else
+                previous_archive ||= OpenStax::Content::Archive.new version: previous_version
+
+                retry_books << OpenStax::Content::Book.new(
+                  archive: previous_archive,
+                  uuid: book.uuid,
+                  version: book.version,
+                  slug: book.slug,
+                  style: book.style
+                )
+              end
+            else
+              pages.each do |page|
+                hash[page.uuid] ||= []
+                hash[page.uuid] << { book: book.slug, page: page.slug }
+              end
             end
           end
+
+          books = retry_books
         end
       end
     end


### PR DESCRIPTION
When a book is not found in the latest archive version, search archive versions backwards until it is found