### PR TITLE
remove old mathjax tag from webview

### DIFF
--- a/app/views/layouts/webview.html.erb
+++ b/app/views/layouts/webview.html.erb
@@ -2,7 +2,6 @@
 <html>
 <head>
   <title>OpenStax Exercises</title>
-  <script src="https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.2/MathJax.js?config=TeX-MML-AM_HTMLorMML-full&amp;delayStartupUntil=configured" async></script>
   <script id="exercises-boostrap-data" type="application/json"><%=raw json_escape client_bootstrap_data.to_json %></script>
   <%= OpenStax::Utilities::Assets.tags_for('exercises') %>
   <%= csrf_meta_tags %>


### PR DESCRIPTION
Doesn't seem to be breaking anything but is throwing errors in the console. The new version attaches the script from the mathjax module.