### PR TITLE
Prevent tags from rarely being randomly deleted when editing an Exercise

### DIFF
--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -1,6 +1,6 @@
 class License < ApplicationRecord
 
-  has_many :publications, dependent: :destroy
+  has_many :publications
   has_many :class_licenses, dependent: :destroy
 
   has_many :combined_license_compatibilities,

--- a/app/models/publication.rb
+++ b/app/models/publication.rb
@@ -12,7 +12,6 @@ class Publication < ApplicationRecord
                               dependent: :destroy,
                               inverse_of: :derived_publication
   has_many :derivations, foreign_key: :source_publication_id,
-                         dependent: :destroy,
                          inverse_of: :source_publication
 
   delegate :group_uuid, :number, :nickname, :nickname=,

--- a/app/models/publication_group.rb
+++ b/app/models/publication_group.rb
@@ -2,11 +2,11 @@ class PublicationGroup < ApplicationRecord
 
   PUSLISHABLE_TYPES_WITH_DEFAULT_PUBLIC_SOLUTIONS = Set[ 'VocabTerm' ]
 
-  has_many :publications, dependent: :destroy, inverse_of: :publication_group, autosave: true
+  has_many :publications, inverse_of: :publication_group, autosave: true
 
   has_many :list_publication_groups, dependent: :destroy
 
-  has_many :vocab_distractors, dependent: :destroy
+  has_many :vocab_distractors
 
   validates :publishable_type, presence: true
   validates :uuid, presence: true, uniqueness: true

--- a/app/models/question.rb
+++ b/app/models/question.rb
@@ -10,7 +10,7 @@ class Question < ApplicationRecord
   sortable_has_many :answers, dependent: :destroy, inverse_of: :question, autosave: true
 
   has_many :collaborator_solutions, dependent: :destroy
-  has_many :community_solutions, dependent: :destroy
+  has_many :community_solutions
 
   sortable_has_many :hints, dependent: :destroy, inverse_of: :question
 

--- a/app/models/tag.rb
+++ b/app/models/tag.rb
@@ -1,7 +1,7 @@
 class Tag < ApplicationRecord
 
-  has_many :exercise_tags, dependent: :destroy
-  has_many :vocab_term_tags, dependent: :destroy
+  has_many :exercise_tags
+  has_many :vocab_term_tags
 
   validates :name, presence: true, uniqueness: true, format: /\A[\w\.:#-]*\z/
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,22 +9,19 @@ class User < ApplicationRecord
   has_many :groups_as_member, through: :account
   has_many :groups_as_owner, through: :account
 
-  has_one :administrator, dependent: :destroy
+  has_one :administrator
 
-  has_many :authors, dependent: :destroy
-  has_many :copyright_holders, dependent: :destroy
+  has_many :authors
+  has_many :copyright_holders
 
   has_many :delegations_as_delegator, class_name: 'Delegation',
                                       foreign_key: :delegator_id,
-                                      dependent: :destroy,
                                       inverse_of: :delegator
-  has_many :delegations_as_delegate, class_name: 'Delegation',
-                                     as: :delegate,
-                                     dependent: :destroy
+  has_many :delegations_as_delegate, class_name: 'Delegation', as: :delegate
 
-  has_many :sortings, dependent: :destroy
+  has_many :sortings
 
-  has_many :applications, as: :owner, class_name: 'Doorkeeper::Application', dependent: :destroy
+  has_many :applications, as: :owner, class_name: 'Doorkeeper::Application'
 
   validates :account, uniqueness: true
 

--- a/db/migrate/20220523181437_fix_foreign_keys.rb
+++ b/db/migrate/20220523181437_fix_foreign_keys.rb
@@ -1,0 +1,49 @@
+class FixForeignKeys < ActiveRecord::Migration[6.1]
+  def change
+    remove_foreign_key :exercise_tags, :exercises, on_update: :cascade, on_delete: :cascade
+    remove_foreign_key :exercise_tags, :tags, on_update: :cascade, on_delete: :cascade
+    remove_foreign_key :vocab_term_tags, :tags, on_update: :cascade, on_delete: :cascade
+    remove_foreign_key :vocab_term_tags, :vocab_terms, on_update: :cascade, on_delete: :cascade
+
+    add_foreign_key :administrators, :users
+    add_foreign_key :answers, :questions
+    add_foreign_key :authors, :publications
+    add_foreign_key :authors, :users
+    add_foreign_key :class_licenses, :licenses
+    add_foreign_key :collaborator_solutions, :questions
+    add_foreign_key :combo_choice_answers, :combo_choices
+    add_foreign_key :combo_choice_answers, :answers
+    add_foreign_key :combo_choices, :stems
+    add_foreign_key :community_solutions, :questions
+    add_foreign_key :copyright_holders, :publications
+    add_foreign_key :copyright_holders, :users
+    add_foreign_key :delegations, :users, column: :delegator_id
+    add_foreign_key :derivations, :publications, column: :derived_publication_id
+    add_foreign_key :derivations, :publications, column: :source_publication_id
+    add_foreign_key :exercise_tags, :exercises
+    add_foreign_key :exercise_tags, :tags
+    add_foreign_key :exercises, :vocab_terms
+    add_foreign_key :hints, :questions
+    add_foreign_key :license_compatibilities, :licenses, column: :combined_license_id
+    add_foreign_key :license_compatibilities, :licenses, column: :original_license_id
+    add_foreign_key :list_editors, :lists
+    add_foreign_key :list_nestings, :lists, column: :child_list_id
+    add_foreign_key :list_nestings, :lists, column: :parent_list_id
+    add_foreign_key :list_owners, :lists
+    add_foreign_key :list_readers, :lists
+    add_foreign_key :logic_variable_values, :logic_variables
+    add_foreign_key :logic_variables, :logics
+    add_foreign_key :publications, :licenses
+    add_foreign_key :publications, :publication_groups
+    add_foreign_key :question_dependencies, :questions, column: :dependent_question_id
+    add_foreign_key :question_dependencies, :questions, column: :parent_question_id
+    add_foreign_key :questions, :exercises
+    add_foreign_key :stem_answers, :answers
+    add_foreign_key :stem_answers, :stems
+    add_foreign_key :stems, :questions
+    add_foreign_key :users, :openstax_accounts_accounts, column: :account_id
+    add_foreign_key :vocab_distractors, :vocab_terms
+    add_foreign_key :vocab_term_tags, :tags
+    add_foreign_key :vocab_term_tags, :vocab_terms
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_03_02_162344) do
+ActiveRecord::Schema.define(version: 2022_05_23_181437) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "citext"
@@ -565,12 +565,48 @@ ActiveRecord::Schema.define(version: 2022_03_02_162344) do
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
-  add_foreign_key "exercise_tags", "exercises", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "exercise_tags", "tags", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "administrators", "users"
+  add_foreign_key "answers", "questions"
+  add_foreign_key "authors", "publications"
+  add_foreign_key "authors", "users"
+  add_foreign_key "class_licenses", "licenses"
+  add_foreign_key "collaborator_solutions", "questions"
+  add_foreign_key "combo_choice_answers", "answers"
+  add_foreign_key "combo_choice_answers", "combo_choices"
+  add_foreign_key "combo_choices", "stems"
+  add_foreign_key "community_solutions", "questions"
+  add_foreign_key "copyright_holders", "publications"
+  add_foreign_key "copyright_holders", "users"
+  add_foreign_key "delegations", "users", column: "delegator_id"
+  add_foreign_key "derivations", "publications", column: "derived_publication_id"
+  add_foreign_key "derivations", "publications", column: "source_publication_id"
+  add_foreign_key "exercise_tags", "exercises"
+  add_foreign_key "exercise_tags", "tags"
+  add_foreign_key "exercises", "vocab_terms"
+  add_foreign_key "hints", "questions"
+  add_foreign_key "license_compatibilities", "licenses", column: "combined_license_id"
+  add_foreign_key "license_compatibilities", "licenses", column: "original_license_id"
+  add_foreign_key "list_editors", "lists"
+  add_foreign_key "list_nestings", "lists", column: "child_list_id"
+  add_foreign_key "list_nestings", "lists", column: "parent_list_id"
+  add_foreign_key "list_owners", "lists"
   add_foreign_key "list_publication_groups", "lists"
   add_foreign_key "list_publication_groups", "publication_groups"
+  add_foreign_key "list_readers", "lists"
+  add_foreign_key "logic_variable_values", "logic_variables"
+  add_foreign_key "logic_variables", "logics"
   add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
   add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
-  add_foreign_key "vocab_term_tags", "tags", on_update: :cascade, on_delete: :cascade
-  add_foreign_key "vocab_term_tags", "vocab_terms", on_update: :cascade, on_delete: :cascade
+  add_foreign_key "publications", "licenses"
+  add_foreign_key "publications", "publication_groups"
+  add_foreign_key "question_dependencies", "questions", column: "dependent_question_id"
+  add_foreign_key "question_dependencies", "questions", column: "parent_question_id"
+  add_foreign_key "questions", "exercises"
+  add_foreign_key "stem_answers", "answers"
+  add_foreign_key "stem_answers", "stems"
+  add_foreign_key "stems", "questions"
+  add_foreign_key "users", "openstax_accounts_accounts", column: "account_id"
+  add_foreign_key "vocab_distractors", "vocab_terms"
+  add_foreign_key "vocab_term_tags", "tags"
+  add_foreign_key "vocab_term_tags", "vocab_terms"
 end

--- a/lib/ar_collection_setter.rb
+++ b/lib/ar_collection_setter.rb
@@ -1,19 +1,5 @@
 AR_COLLECTION_SETTER = ->(input:, binding:, **) do
-   getter = binding[:getter]
-   collection = getter.nil? ? send(binding.getter) : getter.evaluate(self)
-
-  # Hard-delete records that are being replaced
-  # Any further dependent records must be handled with foreign key constraints
-  if collection.is_a?(ActiveRecord::Associations::CollectionProxy)
-    if collection.respond_to?(:loaded?) && !collection.loaded?
-      collection.delete_all :delete_all
-    else
-      collection.group_by(&:class).each do |klass, items|
-        klass.where(id: items.map(&:id)).delete_all
-      end
-    end
-  end
-
-  # Don't use the collection= method (setter) so we can return meaningful errors
-  input.each { |record| collection << record }
+  getter = binding[:getter]
+  collection = getter.nil? ? send(binding.getter) : getter.evaluate(self)
+  collection.replace input
 end

--- a/lib/has_tags.rb
+++ b/lib/has_tags.rb
@@ -3,19 +3,24 @@ module HasTags
     module Base
       def has_tags(association_name = nil, options = {})
         association_name ||= "#{name.tableize.singularize}_tags"
+        join_association = association_name.to_sym
         inverse_association_name = options[:inverse_of] || name.tableize.singularize
         tagging_class = association_name.to_s.classify.constantize
 
         class_exec do
-          has_many association_name.to_sym, { dependent: :destroy, autosave: true }.merge(options)
-          has_many :tags, through: association_name.to_sym do
+          has_many join_association, { dependent: :destroy, autosave: true }.merge(options)
+          has_many :tags, through: join_association do
             def <<(tag)
-              super(Tag.get(tag))
+              super Tag.get(tag)
+            end
+
+            def replace(other_array)
+              super Tag.get(other_array)
             end
           end
 
           def tags=(tags)
-            super(Tag.get(tags))
+            super Tag.get(tags)
           end
         end
       end

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe License, type: :model do
 
   subject(:license) { FactoryBot.create(:license) }
 
-  it { is_expected.to have_many(:publications).dependent(:destroy) }
+  it { is_expected.to have_many(:publications) }
   it { is_expected.to have_many(:class_licenses).dependent(:destroy) }
 
   it { is_expected.to have_many(:combined_license_compatibilities).dependent(:destroy) }

--- a/spec/models/publication_group_spec.rb
+++ b/spec/models/publication_group_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe PublicationGroup, type: :model do
 
   subject(:publication_group) { FactoryBot.create :publication_group }
 
-  it { is_expected.to have_many(:publications).dependent(:destroy) }
+  it { is_expected.to have_many(:publications) }
 
   it { is_expected.to validate_presence_of(:publishable_type) }
   it { is_expected.to validate_presence_of(:uuid) }

--- a/spec/models/publication_spec.rb
+++ b/spec/models/publication_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Publication, type: :model do
   it { is_expected.to have_many(:copyright_holders).dependent(:destroy) }
 
   it { is_expected.to have_many(:sources).dependent(:destroy) }
-  it { is_expected.to have_many(:derivations).dependent(:destroy) }
+  it { is_expected.to have_many(:derivations) }
 
   it { is_expected.to validate_uniqueness_of(:uuid).case_insensitive }
   it { is_expected.to validate_uniqueness_of(:version).scoped_to(:publication_group_id) }

--- a/spec/models/question_spec.rb
+++ b/spec/models/question_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Question, type: :model do
   it { is_expected.to have_many(:stems).dependent(:destroy) }
   it { is_expected.to have_many(:answers).dependent(:destroy) }
   it { is_expected.to have_many(:collaborator_solutions).dependent(:destroy) }
-  it { is_expected.to have_many(:community_solutions).dependent(:destroy) }
+  it { is_expected.to have_many(:community_solutions) }
 
   it { is_expected.to have_many(:hints).dependent(:destroy) }
 

--- a/spec/models/tag_spec.rb
+++ b/spec/models/tag_spec.rb
@@ -4,7 +4,8 @@ require 'rails_helper'
 RSpec.describe Tag, type: :model do
   subject(:tag) { FactoryBot.create :tag }
 
-  it { is_expected.to have_many(:exercise_tags).dependent(:destroy) }
+  it { is_expected.to have_many(:exercise_tags) }
+  it { is_expected.to have_many(:vocab_term_tags) }
 
   it { is_expected.to validate_presence_of(:name) }
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,15 +5,15 @@ RSpec.describe User, type: :model do
 
   it { is_expected.to belong_to(:account) }
 
-  it { is_expected.to have_one(:administrator).dependent(:destroy) }
+  it { is_expected.to have_one(:administrator) }
 
-  it { is_expected.to have_many(:authors).dependent(:destroy) }
-  it { is_expected.to have_many(:copyright_holders).dependent(:destroy) }
+  it { is_expected.to have_many(:authors) }
+  it { is_expected.to have_many(:copyright_holders) }
 
-  it { is_expected.to have_many(:delegations_as_delegator).dependent(:destroy) }
-  it { is_expected.to have_many(:delegations_as_delegate).dependent(:destroy)  }
+  it { is_expected.to have_many(:delegations_as_delegator) }
+  it { is_expected.to have_many(:delegations_as_delegate)  }
 
-  it { is_expected.to have_many(:applications).dependent(:destroy) }
+  it { is_expected.to have_many(:applications) }
 
   it { is_expected.to validate_uniqueness_of(:account) }
 

--- a/spec/representers/api/v1/exercises/question_representer_spec.rb
+++ b/spec/representers/api/v1/exercises/question_representer_spec.rb
@@ -55,8 +55,8 @@ module Api::V1::Exercises
 
       it 'can be written' do
         stems = [ Stem.new(content: "Don't you agree?") ]
-        expect(question.stems).to receive(:<<).with(kind_of(Stem)) do |stem|
-          expect(stem.content).to eq "Don't you agree?"
+        expect(question.stems).to receive(:replace).with([kind_of(Stem)]) do |stems|
+          expect(stems.first.content).to eq "Don't you agree?"
         end
 
         described_class.new(question).from_hash(
@@ -77,8 +77,8 @@ module Api::V1::Exercises
       end
 
       it 'can be written' do
-        expect(question.answers).to receive(:<<).with(kind_of(Answer)).exactly(3).times do |answer|
-          expect(answer.content).to be_in [ 'Yes', 'No', 'Maybe so' ]
+        expect(question.answers).to receive(:replace).with([kind_of(Answer)]*3) do |answers|
+          expect(answers.map(&:content)).to eq [ 'Yes', 'No', 'Maybe so' ]
         end
 
         described_class.new(question).from_hash(
@@ -102,10 +102,10 @@ module Api::V1::Exercises
 
       it 'can be written' do
         expect(question.collaborator_solutions).to(
-          receive(:<<).with(kind_of(CollaboratorSolution)) do |collaborator_solution|
-            expect(collaborator_solution.title).to eq 'Test'
-            expect(collaborator_solution.solution_type).to eq 'example'
-            expect(collaborator_solution.content).to eq 'This is a test.'
+          receive(:replace).with([kind_of(CollaboratorSolution)]) do |collaborator_solutions|
+            expect(collaborator_solutions.first.title).to eq 'Test'
+            expect(collaborator_solutions.first.solution_type).to eq 'example'
+            expect(collaborator_solutions.first.content).to eq 'This is a test.'
           end
         )
 
@@ -132,7 +132,7 @@ module Api::V1::Exercises
       end
 
       it 'cannot be written (attempts are silently ignored)' do
-        expect(question.community_solutions).not_to receive(:<<)
+        expect(question.community_solutions).not_to receive(:replace)
 
         described_class.new(question).from_hash(
           {
@@ -155,8 +155,8 @@ module Api::V1::Exercises
       end
 
       it 'can be written' do
-        expect(question.hints).to receive(:<<).with(kind_of(Hint)) do |hint|
-          expect(hint.content).to eq 'A hint'
+        expect(question.hints).to receive(:replace).with([kind_of(Hint)]) do |hints|
+          expect(hints.first.content).to eq 'A hint'
         end
 
         described_class.new(question).from_hash('hints' => [ 'A hint' ])
@@ -170,10 +170,10 @@ module Api::V1::Exercises
 
       it 'can be written' do
         expect(question.parent_dependencies).to(
-          receive(:<<).with(kind_of(QuestionDependency)) do |question_dependency|
-            expect(question_dependency.dependent_question).to eq question
-            expect(question_dependency.parent_question).to eq question
-            expect(question_dependency.is_optional).to eq true
+          receive(:replace).with([kind_of(QuestionDependency)]) do |question_dependencies|
+            expect(question_dependencies.first.dependent_question).to eq question
+            expect(question_dependencies.first.parent_question).to eq question
+            expect(question_dependencies.first.is_optional).to eq true
           end
         )
 

--- a/spec/representers/api/v1/exercises/representer_spec.rb
+++ b/spec/representers/api/v1/exercises/representer_spec.rb
@@ -138,8 +138,8 @@ module Api::V1::Exercises
 
       it 'can be written' do
         expect(exercise.questions).to(
-          receive(:<<).with(kind_of(Question)).exactly(3).times do |question|
-            expect(question.stimulus).to be_in [ 'Question 1', 'Question 2', 'Question 3' ]
+          receive(:replace).with([kind_of(Question)]*3) do |questions|
+            expect(questions.map(&:stimulus)).to eq [ 'Question 1', 'Question 2', 'Question 3' ]
           end
         )
 

--- a/spec/representers/api/v1/exercises/simple_question_representer_spec.rb
+++ b/spec/representers/api/v1/exercises/simple_question_representer_spec.rb
@@ -73,8 +73,8 @@ module Api::V1::Exercises
       end
 
       it 'can be written' do
-        expect(question.answers).to receive(:<<).with(kind_of(Answer)).exactly(3).times do |answer|
-          expect(answer.content).to be_in [ 'Yes', 'No', 'Maybe so' ]
+        expect(question.answers).to receive(:replace).with([kind_of(Answer)]*3) do |answers|
+          expect(answers.map(&:content)).to eq [ 'Yes', 'No', 'Maybe so' ]
         end
 
         described_class.new(question).from_hash(
@@ -98,10 +98,10 @@ module Api::V1::Exercises
 
       it 'can be written' do
         expect(question.collaborator_solutions).to(
-          receive(:<<).with(kind_of(CollaboratorSolution)) do |collaborator_solution|
-            expect(collaborator_solution.title).to eq 'Test'
-            expect(collaborator_solution.solution_type).to eq 'example'
-            expect(collaborator_solution.content).to eq 'This is a test.'
+          receive(:replace).with([kind_of(CollaboratorSolution)]) do |collaborator_solutions|
+            expect(collaborator_solutions.first.title).to eq 'Test'
+            expect(collaborator_solutions.first.solution_type).to eq 'example'
+            expect(collaborator_solutions.first.content).to eq 'This is a test.'
           end
         )
 
@@ -128,7 +128,7 @@ module Api::V1::Exercises
       end
 
       it 'cannot be written (attempts are silently ignored)' do
-        expect(question.community_solutions).not_to receive(:<<)
+        expect(question.community_solutions).not_to receive(:replace)
 
         described_class.new(question).from_hash(
           {
@@ -151,8 +151,8 @@ module Api::V1::Exercises
       end
 
       it 'can be written' do
-        expect(question.hints).to receive(:<<).with(kind_of(Hint)) do |hint|
-          expect(hint.content).to eq 'A hint'
+        expect(question.hints).to receive(:replace).with([kind_of(Hint)]) do |hints|
+          expect(hints.first.content).to eq 'A hint'
         end
 
         described_class.new(question).from_hash('hints' => [ 'A hint' ])
@@ -166,8 +166,8 @@ module Api::V1::Exercises
       end
 
       it 'can be written' do
-        expect(stem.stylings).to receive(:<<).twice.with(kind_of(Styling)) do |styling|
-          expect(styling.style).to be_in [ 'multiple-choice', 'free-response' ]
+        expect(stem.stylings).to receive(:replace).with([kind_of(Styling)]*2) do |stylings|
+          expect(stylings.map(&:style)).to eq [ 'multiple-choice', 'free-response' ]
         end
 
         described_class.new(question).from_hash('formats' => [ 'multiple-choice', 'free-response' ])
@@ -184,10 +184,12 @@ module Api::V1::Exercises
       end
 
       it 'can be written' do
-        expect(stem.combo_choices).to receive(:<<).with(kind_of(ComboChoice)) do |combo_choice|
-          expect(combo_choice.combo_choice_answers).to eq []
-          expect(combo_choice.correctness).to eq 0.0
-        end
+        expect(stem.combo_choices).to(
+          receive(:replace).with([kind_of(ComboChoice)]) do |combo_choices|
+            expect(combo_choices.first.combo_choice_answers).to eq []
+            expect(combo_choices.first.correctness).to eq 0.0
+          end
+        )
 
         described_class.new(question).from_hash(
           'combo_choices' => [ { 'combo_choice_answers' => [], 'correctness' => 0.0 } ]

--- a/spec/representers/api/v1/vocabs/term_with_distractors_and_exercise_ids_representer_spec.rb
+++ b/spec/representers/api/v1/vocabs/term_with_distractors_and_exercise_ids_representer_spec.rb
@@ -55,10 +55,8 @@ module Api::V1::Vocabs
         end
 
         expect(vocab_term.vocab_distractors).to(
-          receive(:<<).with(kind_of(VocabDistractor)).exactly(3).times do |vocab_distractor|
-            expect(vocab_distractor.distractor_term).to be_in(
-              vocab_distractors.map(&:distractor_term)
-            )
+          receive(:replace).with([kind_of(VocabDistractor)]*3) do |vds|
+            expect(vds.map(&:distractor_term)).to eq vocab_distractors.map(&:distractor_term)
           end
         )
 
@@ -92,8 +90,8 @@ module Api::V1::Vocabs
       end
 
       it 'cannot be written (attempts are silently ignored)' do
-        expect(vocab_term.exercises).not_to receive(:<<)
-        expect(vocab_term.exercise_ids).not_to receive(:<<)
+        expect(vocab_term.exercises).not_to receive(:replace)
+        expect(vocab_term.exercise_ids).not_to receive(:replace)
 
         described_class.new(vocab_term).from_hash('exercise_uuids' => [ SecureRandom.uuid ])
       end
@@ -105,8 +103,8 @@ module Api::V1::Vocabs
       end
 
       it 'cannot be written (attempts are silently ignored)' do
-        expect(vocab_term.exercises).not_to receive(:<<)
-        expect(vocab_term.exercise_ids).not_to receive(:<<)
+        expect(vocab_term.exercises).not_to receive(:replace)
+        expect(vocab_term.exercise_ids).not_to receive(:replace)
 
         described_class.new(vocab_term).from_hash('exercise_uids' => ['42@1', '4@2'])
       end

--- a/spec/requests/api/v1/exercises_controller_spec.rb
+++ b/spec/requests/api/v1/exercises_controller_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe Api::V1::ExercisesController, type: :request, api: true, version:
                        .or(ans[:content].matches_any(tested_strings))
                    ).pluck(:id)
 
-          Exercise.where(id: ex_ids).delete_all
+          Exercise.where(id: ex_ids).destroy_all
 
           @exercise_1 = FactoryBot.build(:exercise, :published)
           Api::V1::Exercises::Representer.new(@exercise_1).from_hash(
@@ -403,9 +403,8 @@ RSpec.describe Api::V1::ExercisesController, type: :request, api: true, version:
     before(:all) do
       DatabaseCleaner.start
 
+      Exercise.where(id: @exercise.id).destroy_all
       PublicationGroup.where(id: @exercise.publication.publication_group_id).delete_all
-      Publication.where(id: @exercise.publication.id).delete_all
-      Exercise.where(id: @exercise.id).delete_all
     end
     after(:all) { DatabaseCleaner.clean }
 

--- a/spec/requests/api/v1/exercises_controller_spec.rb
+++ b/spec/requests/api/v1/exercises_controller_spec.rb
@@ -434,10 +434,7 @@ RSpec.describe Api::V1::ExercisesController, type: :request, api: true, version:
       json_answers = @exercise.questions.first.answers
       expect(Set.new db_answers.map(&:content)).to eq(Set.new json_answers.map(&:content))
 
-      db_solutions = new_exercise.questions.first.collaborator_solutions
-      json_solutions = @exercise.questions.first.collaborator_solutions
-
-      expect(Set.new db_solutions.map(&:content)).to eq(Set.new json_solutions.map(&:content))
+      expect(new_exercise.questions.first.collaborator_solutions).to be_empty
 
       expect(new_exercise.authors.first.user).to eq @user_1
       expect(new_exercise.copyright_holders.first.user).to eq @user_1
@@ -492,7 +489,10 @@ RSpec.describe Api::V1::ExercisesController, type: :request, api: true, version:
 
       new_exercise = Exercise.order(:created_at).last
 
-      expect(new_exercise.questions.first.collaborator_solutions).not_to be_empty
+      db_solutions = new_exercise.questions.first.collaborator_solutions
+      json_solutions = @exercise.questions.first.collaborator_solutions
+
+      expect(Set.new db_solutions.map(&:content)).to eq(Set.new json_solutions.map(&:content))
     end
 
     it "fails if the nickname has already been taken" do

--- a/spec/requests/api/v1/vocab_terms_controller_spec.rb
+++ b/spec/requests/api/v1/vocab_terms_controller_spec.rb
@@ -50,8 +50,10 @@ RSpec.describe Api::V1::VocabTermsController, type: :request, api: true, version
           end
 
           tested_strings = ['%lorem%', '%ipsu%', '%draft%']
-          VocabTerm.where(VocabTerm.arel_table[:name].matches_any(tested_strings).or(
-                          VocabTerm.arel_table[:definition].matches_any(tested_strings))).delete_all
+          VocabTerm.where(
+            VocabTerm.arel_table[:name].matches_any(tested_strings).or(
+            VocabTerm.arel_table[:definition].matches_any(tested_strings))
+          ).destroy_all
 
           @vocab_term_1 = FactoryBot.build(:vocab_term, :published)
           Api::V1::Vocabs::TermWithDistractorsAndExerciseIdsRepresenter.new(
@@ -290,9 +292,8 @@ RSpec.describe Api::V1::VocabTermsController, type: :request, api: true, version
     before(:all) do
       DatabaseCleaner.start
 
+      VocabTerm.where(id: @vocab_term.id).destroy_all
       PublicationGroup.where(id: @vocab_term.publication.publication_group_id).delete_all
-      Publication.where(id: @vocab_term.publication.id).delete_all
-      VocabTerm.where(id: @vocab_term.id).delete_all
     end
     after(:all) { DatabaseCleaner.clean }
 

--- a/spec/routines/search_exercises_spec.rb
+++ b/spec/routines/search_exercises_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe SearchExercises, type: :routine do
            .or(st[:content].matches_any(tested_strings))
            .or(ans[:content].matches_any(tested_strings))).pluck(:id)
 
-    Exercise.where(id: ex_ids).delete_all
+    Exercise.where(id: ex_ids).destroy_all
 
     @exercise_1 = Exercise.new
     Api::V1::Exercises::Representer.new(@exercise_1).from_hash(

--- a/spec/routines/search_vocab_terms_spec.rb
+++ b/spec/routines/search_vocab_terms_spec.rb
@@ -7,10 +7,11 @@ RSpec.describe SearchVocabTerms, type: :routine do
     10.times { FactoryBot.create(:vocab_term, :published) }
 
     tested_strings = ["%lorem ipsu%", "%uia dolor sit ame%", "%adipiscing elit%", "draft"]
-    
+
     vt = VocabTerm.arel_table
-    VocabTerm.where(vt[:name].matches_any(tested_strings).or(
-                    vt[:definition].matches_any(tested_strings))).delete_all
+    VocabTerm.where(
+      vt[:name].matches_any(tested_strings).or(vt[:definition].matches_any(tested_strings))
+    ).destroy_all
 
     @vocab_term_1 = FactoryBot.build(:vocab_term, :published)
     Api::V1::Vocabs::TermWithDistractorsAndExerciseIdsRepresenter.new(@vocab_term_1).from_hash(


### PR DESCRIPTION
- Removed most unnecessary dependent: :destroy options
- Added missing foreign key constraints
- Use the replace method in AR_COLLECTION_SETTER