### PR TITLE
Allow per_page to be 0 so we can get search counts without results

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -175,7 +175,7 @@ GEM
     faraday-em_http (1.0.0)
     faraday-em_synchrony (1.0.0)
     faraday-excon (1.1.0)
-    faraday-http-cache (2.2.0)
+    faraday-http-cache (2.4.1)
       faraday (>= 0.8)
     faraday-httpclient (1.0.1)
     faraday-multipart (1.0.4)
@@ -329,7 +329,7 @@ GEM
       rails (>= 3.0)
     openstax_rescue_from (4.1.0)
       rails (>= 3.1, < 7.0)
-    openstax_utilities (4.5.2)
+    openstax_utilities (5.1.0)
       aws-sdk-autoscaling
       faraday
       faraday-http-cache

--- a/app/views/admin/publications/_search_results_pagination.html.erb
+++ b/app/views/admin/publications/_search_results_pagination.html.erb
@@ -5,7 +5,7 @@
   page         ||= 1
   per_page     ||= 20
 
-  num_pages = (total_count.to_f/per_page).ceil
+  num_pages = per_page == 0 ? 1 : (total_count.to_f/per_page).ceil
 %>
 
 <%= pluralize(total_count, 'publication') %> found.

--- a/app/views/shared/users/_search_pagination.html.erb
+++ b/app/views/shared/users/_search_pagination.html.erb
@@ -2,7 +2,7 @@
   page = Integer(params[:page]) rescue 0
   per_page = Integer(params[:per_page]) rescue 20
   num_users = @handler_result&.outputs&.total_count || 0
-  pages = (num_users * 1.0 / per_page).ceil
+  pages = per_page == 0 ? 1 : (num_users * 1.0 / per_page).ceil
 %>
 
 <div id='search-results-pagination'>

--- a/config/initializers/openstax_utilities.rb
+++ b/config/initializers/openstax_utilities.rb
@@ -6,4 +6,13 @@ OpenStax::Utilities.configure do |config|
 
     raise SecurityTransgression
   end
+
+  secrets = Rails.application.secrets
+  config.assets_url = secrets.assets_url
+  config.environment_name = secrets.environment_name
+  config.backend = 'exercises'
+  config.frontend = 'tutor-js'
+  config.release_version = secrets.release_version
+  config.deployment = 'tutor-deployment'
+  config.deployment_version = secrets.deployment_version
 end


### PR DESCRIPTION
For: https://github.com/openstax/unified/issues/2213

The openstax_utilities update allows per_page to be 0. The other changes are to prevent divisions by 0 when that happens.

This should allow us to speed up Exercises queries in a couple of places by getting only the exercise counts rather than actual results.