### PR TITLE
Miscellaneous fixes from RAISE imports

### DIFF
--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -77,8 +77,6 @@ test:
       region: us-east-1
       exports_bucket_name: not-a-real-bucket
       uploads_bucket_name: not-a-real-bucket
-      access_key_id: NOTAREALKEY
-      secret_access_key: NOTAREALSECRET
 
 # Do not keep production secrets in the repository,
 # instead read values from the environment.

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -121,5 +121,3 @@ production:
       region: <%= ENV['AWS_S3_REGION'] %>
       exports_bucket_name: <%= ENV['AWS_S3_EXPORTS_BUCKET_NAME'] %>
       uploads_bucket_name: <%= ENV['AWS_S3_UPLOADS_BUCKET_NAME'] %>
-      access_key_id: <%= ENV['AWS_S3_ACCESS_KEY_ID'] %>
-      secret_access_key: <%= ENV['AWS_S3_SECRET_ACCESS_KEY'] %>

--- a/lib/openstax_kramdown.rb
+++ b/lib/openstax_kramdown.rb
@@ -16,11 +16,7 @@ class Kramdown::Parser::Openstax < Kramdown::Parser::Html
   end
 
   def s3_client
-    args = { region: region }
-    args[:credentials] = Aws::Credentials.new(s3_secrets[:access_key_id], s3_secrets[:secret_access_key]) \
-      unless Rails.env.production?
-
-    @s3_client ||= Aws::S3::Client.new(**args)
+    @s3_client ||= Aws::S3::Client.new(region: region)
   end
 
   def add_text(text, tree = @tree, type = @text_type)

--- a/lib/openstax_kramdown.rb
+++ b/lib/openstax_kramdown.rb
@@ -41,7 +41,7 @@ class Kramdown::Parser::Openstax < Kramdown::Parser::Html
       last_el = @tree.children.last
       next unless last_el.type == :html_element && last_el.value == 'img' && last_el.attr['src']
 
-      uri = URI.parse(last_el.attr['src'])
+      uri = URI.parse(last_el.attr['src'].strip)
       contents = Net::HTTP.get(uri)
 
       bucket_name = s3_secrets[:uploads_bucket_name]


### PR DESCRIPTION
- Match more headers in the spreadsheets
- Fix NoMethodError when book not in ABL
- Use correct "styling" (format) for free-response imports
- Don't set AWS key/secret key in production (instances don't use them)
- Don't try to create duplicate Attachments