### PR TITLE
Handle cnxmod tags for Assignable exercises

### DIFF
--- a/app/routines/exercises/tag/assessments.rb
+++ b/app/routines/exercises/tag/assessments.rb
@@ -15,6 +15,9 @@ module Exercises
       def exec(filename:, book_uuid:)
         Rails.logger.info { "Filename: #{filename}" }
 
+        book = OpenStax::Content::Abl.new.books.find { |book| book.uuid == book_uuid }
+        all_cnxmod_tags = book.all_pages.map { |page| "context-cnxmod:#{page.uuid}" }
+
         uuid_index = nil
         pre_indices = nil
         post_indices = nil
@@ -62,13 +65,21 @@ module Exercises
 
             pre_section_tag = "assessment:preparedness:https://openstax.org/orn/book:page/#{book_uuid}:#{page_uuid}"
             post_section_tag = "assessment:practice:https://openstax.org/orn/book:page/#{book_uuid}:#{page_uuid}"
+            cnxmod_tag = "context-cnxmod:#{page_uuid}"
+
+            # Normally pre-section exercises don't get cnxmod tags,
+            # unless they have no cnxmod tags for the entire book
+            pre_section_ex_with_cnxmod, pre_section_ex_missing_cnxmod = pre_section_exercises.partition do |ex|
+              ex.tags.any? { |tag| all_cnxmod_tags.include? tag.name }
+            end
 
             row_number = row_index + 1
 
             begin
-              tag pre_and_post_section_exercises, [ pre_section_tag, post_section_tag ]
-              tag pre_section_exercises, [ pre_section_tag ]
-              tag post_section_exercises, [ post_section_tag ]
+              tag pre_and_post_section_exercises, [ pre_section_tag, post_section_tag, cnxmod_tag ]
+              tag pre_section_ex_with_cnxmod, [ pre_section_tag ]
+              tag pre_section_ex_missing_cnxmod, [ pre_section_tag, cnxmod_tag ]
+              tag post_section_exercises, [ post_section_tag, cnxmod_tag ]
             rescue StandardError => se
               Rails.logger.error { "Failed to import row ##{row_number} - #{se.message}" }
               failures[row_number] = se.to_s


### PR DESCRIPTION
For post-section exercises, always tag them with the cnxmod tag of the section they are tagged for.
For pre-section exercises, tag them only if they don't already have a cnxmod tag for that book at all.