### PR TITLE
Support data-lang in user HTML

### DIFF
--- a/config/initializers/user_html.rb
+++ b/config/initializers/user_html.rb
@@ -42,7 +42,7 @@ embed_transformer = ->(env) do
   { node_whitelist: [node] }
 end
 
-STYLE_DATA_ATTRIBUTES = %w(bullet-style type orient valign align media)
+STYLE_DATA_ATTRIBUTES = %w(bullet-style type orient valign align media lang)
 STYLE_ATTRIBUTES = STYLE_DATA_ATTRIBUTES.map { |attr| "data-#{attr}" }
 
 UserHtml.sanitize_config = Sanitize::Config.merge(

--- a/config/initializers/user_html.rb
+++ b/config/initializers/user_html.rb
@@ -42,7 +42,7 @@ embed_transformer = ->(env) do
   { node_whitelist: [node] }
 end
 
-STYLE_DATA_ATTRIBUTES = %w(bullet-style type orient valign align media lang)
+STYLE_DATA_ATTRIBUTES = %w(bullet-style type orient valign align media)
 STYLE_ATTRIBUTES = STYLE_DATA_ATTRIBUTES.map { |attr| "data-#{attr}" }
 
 UserHtml.sanitize_config = Sanitize::Config.merge(
@@ -56,6 +56,8 @@ UserHtml.sanitize_config = Sanitize::Config.merge(
     'span' => ['data-math'],
     'div'  => ['data-math', 'align'],
     'p'    => ['align'],
+    'pre'  => ['data-lang'],
+    'code' => ['data-lang'],
   ),
   transformers: [embed_transformer]
 )


### PR DESCRIPTION
https://openstax.atlassian.net/browse/CORE-1681

Part of converting lang to data-lang to meet WCAG requirements (3.1.2)

Updated one exercise in python, and all the shiny new data-lang attributes were gone 💥 😂 

For context, this data-lang attribute is used to style code (like `data-lang="python"`. 